### PR TITLE
Revert 1 change from PR #8 as requested

### DIFF
--- a/MetriCam2/Camera.cs
+++ b/MetriCam2/Camera.cs
@@ -674,6 +674,7 @@ namespace MetriCam2
                     try
                     {
                         castedValue = (T)Convert.ChangeType(value, this.Type, CultureInfo.InvariantCulture);
+                        isTypeConvertible = (null != castedValue);
                     }
                     catch (ArgumentNullException)
                     { /* empty */ }
@@ -683,8 +684,6 @@ namespace MetriCam2
                     { /* empty */ }
                     catch (OverflowException)
                     { /* empty */ }
-
-                    isTypeConvertible = (null != castedValue);
                 }
 
                 if (!isTypeConvertible)


### PR DESCRIPTION
> @mischastik, @jangernert: Is das korrekt, diese Zuweisung aus dem try-Block rauszuziehen?
Nehmen wir an, bei `ChangeType` wuerde eine Exception fliegen. Dann wuerde ich erwarten, dass `isTypeConvertible` den Wert `false` bekommt.
`castedValue` hat dann allerdings den Wert `default(T)`, und das ist bei einem ValueType nicht `null`, also waere `isTypeConvertible` dann `true`.

New PR because
> Once a pull request is merged and closed, it is locked forever and cannot be reopened.