### PR TITLE
Make MetriCam2 .NET Standard 2.0 compatible

### DIFF
--- a/MetriCam2/Camera.cs
+++ b/MetriCam2/Camera.cs
@@ -2722,6 +2722,9 @@ namespace MetriCam2
         {
             log.Debug("GetCalibrationPathFromRegistry");
 
+#if NETSTANDARD2_0
+            return null;
+#else
             if (null != calibrationPathRegistry)
             {
                 log.DebugFormat("  using cached value: '{0}'", calibrationPathRegistry);
@@ -2770,6 +2773,7 @@ namespace MetriCam2
             log.DebugFormat(@"Calibration path = '{0}'", calibrationPathRegistry);
 
             return calibrationPathRegistry;
+#endif
         }
 
         /// <summary>

--- a/MetriCam2/CameraManagement.cs
+++ b/MetriCam2/CameraManagement.cs
@@ -723,6 +723,7 @@ namespace MetriCam2
 
         private void LoadRegistryDirectoryAssemblies()
         {
+#if !NETSTANDARD2_0
             RegistryKey rk = Registry.LocalMachine; // HKLM
             string[] subkeys = new string[] { "SOFTWARE", "Metrilus GmbH" };
 
@@ -753,6 +754,7 @@ namespace MetriCam2
             }
             catch
             { /* empty */ }
+#endif
         }
 
         private void LoadLocalDirectoryAssemblies()
@@ -829,6 +831,6 @@ namespace MetriCam2
         /// <returns></returns>
         [DllImport("kernel32.dll")]
         private static extern IntPtr LoadLibrary(string dllToLoad);
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
Exclude Registry stuff from Camera and CameraManagement for .NET Standard 2.0 builds.