### PR TITLE
Orbbec improvements

### DIFF
--- a/BetaCameras/OrbbecOpenNI/AssemblyInfo.cpp
+++ b/BetaCameras/OrbbecOpenNI/AssemblyInfo.cpp
@@ -2,6 +2,7 @@
 // MetriCam 2 is licensed under the MIT license. See License.txt for full license text.
 
 #include "stdafx.h"
+#include "../../SolutionAssemblyInfo.h"
 
 using namespace System;
 using namespace System::Reflection;
@@ -14,27 +15,9 @@ using namespace System::Security::Permissions;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 //
-[assembly:AssemblyTitleAttribute(L"OrbbecOpenNI")];
-[assembly:AssemblyDescriptionAttribute(L"")];
-[assembly:AssemblyConfigurationAttribute(L"")];
-[assembly:AssemblyCompanyAttribute(L"")];
-[assembly:AssemblyProductAttribute(L"OrbbecOpenNI")];
-[assembly:AssemblyCopyrightAttribute(L"Copyright (c)  2017")];
-[assembly:AssemblyTrademarkAttribute(L"")];
-[assembly:AssemblyCultureAttribute(L"")];
-
-//
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the value or you can default the Revision and Build Numbers
-// by using the '*' as shown below:
-
-[assembly:AssemblyVersionAttribute("1.0.*")];
+[assembly:AssemblyTitleAttribute(L"MetriCam2: Orbbec/OpenNI2 wrapper")];
+[assembly:AssemblyDescriptionAttribute(L"MetriCam2 wrapper for Orbbec cameras using OpenNI2")];
+[assembly:MetriCam2::Attributes::ContainsCameraImplementations]
 
 [assembly:ComVisible(false)];
 

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -777,6 +777,7 @@ Metrilus::Util::IProjectiveTransformation^ MetriCam2::Cameras::AstraOpenNI::GetI
 	log->Info("Projective transformation file not found.");
 	log->Info("Using Orbbec factory intrinsics as projective transformation.");
 
+	Metrilus::Util::ProjectiveTransformationZhang^ pt = nullptr;
 	ParamsResult res = _pCamData->openNICam->get_cmos_params(0);
 
 	if (channelName->Equals(ChannelNames::Intensity) || channelName->Equals(ChannelNames::ZImage))
@@ -784,9 +785,9 @@ Metrilus::Util::IProjectiveTransformation^ MetriCam2::Cameras::AstraOpenNI::GetI
 		if (res.error)
 		{
 			//Extracted from 3-D coordinates
-			return gcnew Metrilus::Util::ProjectiveTransformationZhang(640, 480, 570.3422f, 570.3422f, 320, 240, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+			pt = gcnew Metrilus::Util::ProjectiveTransformationZhang(640, 480, 570.3422f, 570.3422f, 320, 240, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 		}
-		return gcnew Metrilus::Util::ProjectiveTransformationZhang(
+		pt = gcnew Metrilus::Util::ProjectiveTransformationZhang(
 			640,
 			480,
 			res.params.l_intr_p[0],
@@ -805,9 +806,9 @@ Metrilus::Util::IProjectiveTransformation^ MetriCam2::Cameras::AstraOpenNI::GetI
 		if (res.error)
 		{
 			// Extracted from file in Orbbec calibration tool
-			return gcnew Metrilus::Util::ProjectiveTransformationZhang(640, 480, 512.408f, 512.999f, 327.955f, 236.763f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+			pt = gcnew Metrilus::Util::ProjectiveTransformationZhang(640, 480, 512.408f, 512.999f, 327.955f, 236.763f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 		}
-		return gcnew Metrilus::Util::ProjectiveTransformationZhang(
+		pt = gcnew Metrilus::Util::ProjectiveTransformationZhang(
 			640,
 			480,
 			res.params.r_intr_p[0],
@@ -821,8 +822,16 @@ Metrilus::Util::IProjectiveTransformation^ MetriCam2::Cameras::AstraOpenNI::GetI
 			res.params.r_k[4]);
 	}
 
-	log->Error(String::Format("Unsupported channel in GetIntrinsics(): {0}", channelName));
-	return nullptr;
+	if (nullptr == pt)
+	{
+		log->Error(String::Format("Unsupported channel in GetIntrinsics(): {0}", channelName));
+	}
+	else
+	{
+		pt->CameraSerial = SerialNumber;
+	}
+
+	return pt;
 }
 
 Metrilus::Util::RigidBodyTransformation^ MetriCam2::Cameras::AstraOpenNI::GetExtrinsics(String^ channelFromName, String^ channelToName)

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -15,22 +15,9 @@
 
 MetriCam2::Cameras::AstraOpenNI::AstraOpenNI()
 {
-	_pCamData = new OrbbecNativeCameraData();
-	_pCamData->openNICam = new cmd();
-
-	_pCamData->depth = new openni::VideoStream();
-	_pCamData->ir = new openni::VideoStream();
-	_pCamData->color = new openni::VideoStream();
-
 	// Init to most reasonable values; update during ConnectImpl
 	_emitterEnabled = true;
 	_irFlooderEnabled = false;
-}
-
-MetriCam2::Cameras::AstraOpenNI::~AstraOpenNI()
-{
-	//TODO: clean up camData->openNICam, camData->depth and camData->ir
-	delete _pCamData;
 }
 
 void MetriCam2::Cameras::AstraOpenNI::LogOpenNIError(String^ status) 
@@ -171,6 +158,13 @@ void MetriCam2::Cameras::AstraOpenNI::LoadAllAvailableChannels()
 
 void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 {
+	_pCamData = new OrbbecNativeCameraData();
+	_pCamData->openNICam = new cmd();
+
+	_pCamData->depth = new openni::VideoStream();
+	_pCamData->ir = new openni::VideoStream();
+	_pCamData->color = new openni::VideoStream();
+
 	bool initSucceeded = OpenNIInit();
 	if (!initSucceeded) 
 	{
@@ -410,6 +404,12 @@ void MetriCam2::Cameras::AstraOpenNI::DisconnectImpl()
 	_pCamData->depth->destroy();
 	_pCamData->ir->destroy();
 	_pCamData->color->destroy();
+	delete _pCamData->depth;
+	delete _pCamData->ir;
+	delete _pCamData->color;
+	delete _pCamData->openNICam;
+	delete _pCamData;
+
 	OpenNIShutdown();
 }
 

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -504,6 +504,8 @@ void MetriCam2::Cameras::AstraOpenNI::ActivateChannelImpl(String^ channelName)
 			throw gcnew Exception("IR and depth are not allowed to be active at the same time. Please deactivate channel \"Intensity\" before activating channel \"ZImage\" or \"Point3DImage\"");
 		}
 
+		auto irGainBefore = _irGain;
+
 		openni::VideoMode depthVideoMode = _pCamData->depth->getVideoMode();
 		depthVideoMode.setResolution(640, 480);
 		_pCamData->depth->setVideoMode(depthVideoMode);
@@ -531,8 +533,11 @@ void MetriCam2::Cameras::AstraOpenNI::ActivateChannelImpl(String^ channelName)
 
 		if (this->IsConnected)
 		{
-			//Activating the depth channel resets the IR gain to the default value -> we need to restore the value that was set before.
-			SetIRGain(_irGain);
+			if (GetIRGain() != irGainBefore)
+			{
+				// Activating the depth channel resets the IR gain to the default value -> we need to restore the value that was set before.
+				SetIRGain(irGainBefore);
+			}
 		}
 	}
 	else if (channelName->Equals(ChannelNames::Intensity))

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -20,6 +20,17 @@ MetriCam2::Cameras::AstraOpenNI::AstraOpenNI()
 	_irFlooderEnabled = false;
 }
 
+MetriCam2::Cameras::AstraOpenNI::~AstraOpenNI()
+{
+	try
+	{
+		if (IsConnected)
+		{
+			Disconnect(true);
+		}
+	}
+	catch (...) {}
+}
 void MetriCam2::Cameras::AstraOpenNI::LogOpenNIError(String^ status) 
 {
 	log->Error(status + "\n" + gcnew String(openni::OpenNI::getExtendedError()));

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -9,13 +9,6 @@
 
 #define MAX_DEVICES 20  // There is no limitations, we choose 20 as "reasonable" value in real use case.
 
-//Adpated from SimpleViewer of experimental interface
-#define IR_Exposure_MAX 0x1000
-#define IR_Exposure_MIN 0x0
-#define IR_Exposure_SCALE 256
-#define IR_Gain_MIN 0x08
-#define IR_Gain_MAX 0x60
-
 // TODO:
 // * support different resolutions (not only VGA) for channels ZImage and Intensity and check whether IR gain/exposure set feature is still working.
 // * At least the mode 1280x1024 seems to be not compatible with the IR exposure set feature. For QVGA there seem to be problems to set the exposure when the Intensity channel is activated.
@@ -202,6 +195,8 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 	{
 		throw gcnew MetriCam2::Exceptions::ConnectionFailedException(String::Format("Could not init connection to device {0}.", SerialNumber));
 	}
+	VendorID = _pCamData->openNICam->m_vid;
+	ProductID = _pCamData->openNICam->m_pid;
 	_pCamData->openNICam->ldp_set(true); //Ensure eye-safety by turning on the proximity sensor
 
 	// Start depth stream

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -61,9 +61,12 @@ namespace MetriCam2
 				}
 				void set(bool value)
 				{
-					_emitterEnabled = value;
-					SetEmitterStatus(_emitterEnabled);
-					log->DebugFormat("Emitter state set to: {0}", _emitterEnabled.ToString());
+					if (value != _emitterEnabled)
+					{
+						_emitterEnabled = value;
+						SetEmitterStatus(_emitterEnabled);
+						log->DebugFormat("Emitter state set to: {0}", _emitterEnabled.ToString());
+					}
 				}
 			}
 
@@ -76,9 +79,12 @@ namespace MetriCam2
 				}
 				void set(bool value)
 				{
-					_irFlooderEnabled = value;
-					SetIRFlooderStatus(_irFlooderEnabled);
-					log->DebugFormat("IR flooder state set to: {0}", _irFlooderEnabled.ToString());
+					if (value != _irFlooderEnabled)
+					{
+						_irFlooderEnabled = value;
+						SetIRFlooderStatus(_irFlooderEnabled);
+						log->DebugFormat("IR flooder state set to: {0}", _irFlooderEnabled.ToString());
+					}
 				}
 			}
 
@@ -90,8 +96,11 @@ namespace MetriCam2
 				}
 				void set(unsigned char value)
 				{
-					_irGain = value;
-					SetIRGain(_irGain);
+					if (value != _irGain)
+					{
+						_irGain = value;
+						SetIRGain(_irGain);
+					}
 				}
 			}
 

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -6,6 +6,13 @@
 #include <OpenNI.h>
 #include "cmd.h"
 
+//Adpated from SimpleViewer of experimental interface
+#define IR_Exposure_MAX 4096
+#define IR_Exposure_MIN 0
+#define IR_Exposure_SCALE 256
+#define IR_Gain_MIN 8
+#define IR_Gain_MAX 96
+
 using namespace System;
 using namespace System::ComponentModel;
 using namespace System::Threading;
@@ -42,24 +49,14 @@ namespace MetriCam2
 			AstraOpenNI();
 			~AstraOpenNI();
 
-			property ParamDesc<bool>^ EmitterEnabledDesc
-			{
-				inline ParamDesc<bool> ^get()
-				{
-					ParamDesc<bool> ^res = gcnew ParamDesc<bool>();
-					res->Unit = "";
-					res->Description = "Emitter is enabled";
-					res->ReadableWhen = ParamDesc::ConnectionStates::Connected | ParamDesc::ConnectionStates::Disconnected;
-					res->WritableWhen = ParamDesc::ConnectionStates::Connected;
-					return res;
-				}
-			}
+			property int ProductID;
+			property int VendorID;
 
 			property bool EmitterEnabled
 			{
 				bool get(void)
 				{
-					//Reader the emitter status via the "cmd" class does not yet work. Check in future version of experimental SDK.
+					// Reading the emitter status via the "cmd" class does not yet work. Check in future version of experimental SDK.
 					return _emitterEnabled;
 				}
 				void set(bool value)
@@ -70,24 +67,11 @@ namespace MetriCam2
 				}
 			}
 
-			property ParamDesc<bool>^ IRFlooderEnabledDesc
-			{
-				inline ParamDesc<bool> ^get()
-				{
-					ParamDesc<bool> ^res = gcnew ParamDesc<bool>();
-					res->Unit = "";
-					res->Description = "IR flooder is enabled";
-					res->ReadableWhen = ParamDesc::ConnectionStates::Connected | ParamDesc::ConnectionStates::Disconnected;
-					res->WritableWhen = ParamDesc::ConnectionStates::Connected;
-					return res;
-				}
-			}
-
 			property bool IRFlooderEnabled
 			{
 				bool get(void)
 				{
-					//Reader the IrFlood status via the "cmd" class does not yet work. Check in future version of experimental SDK.
+					// Reading the IrFlood status via the "cmd" class does not yet work. Check in future version of experimental SDK.
 					return _irFlooderEnabled;
 				}
 				void set(bool value)
@@ -102,12 +86,12 @@ namespace MetriCam2
 			{
 				unsigned char get(void)
 				{
-					return (unsigned char)GetIRGain();
+					return _irGain;
 				}
 				void set(unsigned char value)
 				{
-					SetIRGain(value);
 					_irGain = value;
+					SetIRGain(_irGain);
 				}
 			}
 
@@ -179,6 +163,58 @@ namespace MetriCam2
 			virtual void DeactivateChannelImpl(String^ channelName) override;
 			
 		private:
+			property ParamDesc<bool>^ EmitterEnabledDesc
+			{
+				inline ParamDesc<bool> ^get()
+				{
+					ParamDesc<bool> ^res = gcnew ParamDesc<bool>();
+					res->Unit = "";
+					res->Description = "Emitter is enabled";
+					res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
+					res->WritableWhen = ParamDesc::ConnectionStates::Connected;
+					return res;
+				}
+			}
+
+			property ParamDesc<bool>^ IRFlooderEnabledDesc
+			{
+				inline ParamDesc<bool> ^get()
+				{
+					ParamDesc<bool> ^res = gcnew ParamDesc<bool>();
+					res->Unit = "";
+					res->Description = "IR flooder is enabled";
+					res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
+					res->WritableWhen = ParamDesc::ConnectionStates::Connected;
+					return res;
+				}
+			}
+
+			property ParamDesc<unsigned int>^ IRExposureDesc
+			{
+				inline ParamDesc<unsigned int> ^get()
+				{
+					ParamDesc<unsigned int> ^res = gcnew ParamDesc<unsigned int>();
+					res->Unit = "";
+					res->Description = "IR exposure";
+					res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
+					res->WritableWhen = ParamDesc::ConnectionStates::Connected;
+					return res;
+				}
+			}
+
+			property ParamDesc<int>^ IRGainDesc
+			{
+				inline ParamDesc<int> ^get()
+				{
+					ParamDesc<int> ^res = ParamDesc::BuildRangeParamDesc(IR_Gain_MIN, IR_Gain_MAX);
+					res->Unit = "";
+					res->Description = "IR gain";
+					res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
+					res->WritableWhen = ParamDesc::ConnectionStates::Connected;
+					return res;
+				}
+			}
+
 			FloatCameraImage^ CalcZImage();
 			ColorCameraImage^ CalcColor();
 			Point3fCameraImage^ CalcPoint3fImage();

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -47,6 +47,7 @@ namespace MetriCam2
 		{
 		public:
 			AstraOpenNI();
+			~AstraOpenNI();
 
 			property int ProductID;
 			property int VendorID;

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -47,7 +47,6 @@ namespace MetriCam2
 		{
 		public:
 			AstraOpenNI();
-			~AstraOpenNI();
 
 			property int ProductID;
 			property int VendorID;

--- a/BetaCameras/OrbbecOpenNI/cmd.cpp
+++ b/BetaCameras/OrbbecOpenNI/cmd.cpp
@@ -76,6 +76,8 @@ int cmd::init(const char* deviceURI)
 	if (rc != STATUS_OK)
 	{
 		printf("Couldn't open device\n%s\n", OpenNI::getExtendedError());
+		m_vid = 0;
+		m_pid = 0;
 		return rc;
 	}
 	dInfo = device.getDeviceInfo();

--- a/BetaCameras/OrbbecOpenNI/cmd.h
+++ b/BetaCameras/OrbbecOpenNI/cmd.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #ifdef WIN32

--- a/SolutionAssemblyInfo.cs
+++ b/SolutionAssemblyInfo.cs
@@ -6,7 +6,7 @@
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Metrilus GmbH")]
 [assembly: AssemblyProduct("MetriCam 2")]
-[assembly: AssemblyCopyright("Copyright ©  2013 - 2016")]
+[assembly: AssemblyCopyright("Copyright ©  2013 - 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SolutionAssemblyInfo.h
+++ b/SolutionAssemblyInfo.h
@@ -10,7 +10,7 @@ using namespace System::Security::Permissions;
 [assembly:AssemblyConfigurationAttribute("")];
 [assembly:AssemblyCompanyAttribute("Metrilus GmbH")];
 [assembly:AssemblyProductAttribute("MetriCam 2")];
-[assembly:AssemblyCopyrightAttribute("Copyright ©  2013 - 2016")];
+[assembly:AssemblyCopyrightAttribute("Copyright ©  2013 - 2017")];
 [assembly:AssemblyTrademarkAttribute("")];
 [assembly:AssemblyCultureAttribute("")];
 


### PR DESCRIPTION
* Add VendorID and ProductID properties.
* Fix param-desc visibilities.
* Add param-descs for IRGain and IRExposure.
* Track value of irGain (closes #22).
* Improve Orbbec init sequence  
Fixes reconnect to same MetriCam2 object.
* Improve Orbbec.ActivateChannel  
Call SetIRGain only if needed.
* Fill ChannelName in Calc* methods
* Fill CameraSerial in Gettrinsics