### PR TITLE
Fix NullRefEx in ExceptionBuilder

### DIFF
--- a/MetriCam2/Exceptions/ExceptionBuilder.cs
+++ b/MetriCam2/Exceptions/ExceptionBuilder.cs
@@ -21,10 +21,19 @@ namespace MetriCam2
         #region Private Methods
         private static Exception Build(Type exType, string msg)
         {
-            ConstructorInfo ci = exType.GetConstructor(new Type[] { typeof(string) });
             log.ErrorFormat("{0}: {1}", exType.Name, msg);
-            return (Exception)ci.Invoke(new object[] { msg });
+
+            // Try ctor with message
+            ConstructorInfo ci = exType.GetConstructor(new Type[] { typeof(string) });
+            if (null != ci)
+            {
+                return (Exception)ci.Invoke(new object[] { msg });
+            }
+
+            // Fall-back
+            return new Exception(exType + ": " + msg);
         }
+
         private static void Throw(Type exType, string msg)
         {
             throw Build(exType, msg);


### PR DESCRIPTION
SocketException does not have a ctor with string parameter, so building that exception type resulted in a NullRefEx. Fallback is to neglect the actual exception type in such cases and include it in the message text.