### PR TITLE
Realsense2 fixes

### DIFF
--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -558,9 +558,9 @@ namespace MetriCam2.Cameras
             int height = ColorResolution.Y;
             int width = ColorResolution.X;
 
-            Metrilus.Util.Bitmap bitmap = new Metrilus.Util.Bitmap(width, height, Metrilus.Util.PixelFormat.Format24bppRgb);
+            Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format24bppRgb);
             Rectangle imageRect = new Rectangle(0, 0, width, height);
-            Metrilus.Util.BitmapData bmpData = bitmap.LockBits(imageRect, Metrilus.Util.ImageLockMode.WriteOnly, bitmap.PixelFormat);
+            BitmapData bmpData = bitmap.LockBits(imageRect, ImageLockMode.WriteOnly, bitmap.PixelFormat);
 
             byte* source = (byte*) RealSense2API.GetFrameData(_currentColorFrame);
             byte* target = (byte*) (void*)bmpData.Scan0;

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -155,6 +155,12 @@ namespace MetriCam2.Cameras
             _depthScale = RealSense2API.GetDepthScale(_pipeline);
         }
 
+        public void RestartPipeline()
+        {
+            RealSense2API.PipelineStop(_pipeline);
+            RealSense2API.PipelineStart(_pipeline, _config);
+        }
+
         protected override void DisconnectImpl()
         {
             if (!IsConnected)
@@ -183,7 +189,7 @@ namespace MetriCam2.Cameras
             {
                 RealSense2API.RS2Frame data = RealSense2API.PipelineWaitForFrames(_pipeline, 500);
 
-                if(!data.IsValid())
+                if(!data.IsValid() || data.Handle == IntPtr.Zero)
                 {
                     RealSense2API.ReleaseFrame(data);
                     continue;
@@ -554,9 +560,9 @@ namespace MetriCam2.Cameras
             int height = ColorResolution.Y;
             int width = ColorResolution.X;
 
-            Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format24bppRgb);
+            Metrilus.Util.Bitmap bitmap = new Metrilus.Util.Bitmap(width, height, Metrilus.Util.PixelFormat.Format24bppRgb);
             Rectangle imageRect = new Rectangle(0, 0, width, height);
-            BitmapData bmpData = bitmap.LockBits(imageRect, ImageLockMode.WriteOnly, bitmap.PixelFormat);
+            Metrilus.Util.BitmapData bmpData = bitmap.LockBits(imageRect, Metrilus.Util.ImageLockMode.WriteOnly, bitmap.PixelFormat);
 
             byte* source = (byte*) RealSense2API.GetFrameData(_currentColorFrame);
             byte* target = (byte*) (void*)bmpData.Scan0;
@@ -594,7 +600,7 @@ namespace MetriCam2.Cameras
         {
             RealSense2API.RS2Device dev = RealSense2API.GetActiveDevice(_pipeline);
             RealSense2API.LoadAdvancedConfig(json, dev);
-            RealSense2API.DeleteDevice(dev);
+            //RealSense2API.DeleteDevice(dev);
             _depthScale = RealSense2API.GetDepthScale(_pipeline);
         }
     }

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -140,8 +140,11 @@ namespace MetriCam2.Cameras
                 RealSense2API.EnableDevice(_config, SerialNumber);
             }
 
-            ActivateChannel(ChannelNames.Color);
-            ActivateChannel(ChannelNames.ZImage);
+            if (ActiveChannels.Count == 0)
+            {
+                ActivateChannel(ChannelNames.Color);
+                ActivateChannel(ChannelNames.ZImage);
+            }
 
             RealSense2API.PipelineStart(_pipeline, _config);
 
@@ -157,10 +160,7 @@ namespace MetriCam2.Cameras
 
         protected override void DisconnectImpl()
         {
-            if (!IsConnected)
-                return;
-
-            RealSense2API.PipelineStop(_pipeline);
+            RealSense2API.PipelineStop(_pipeline);            
         }
 
         protected override void UpdateImpl()
@@ -397,6 +397,10 @@ namespace MetriCam2.Cameras
                 stream = RealSense2API.Stream.INFRARED;
             }
 
+            _currentColorFrame = new RealSense2API.RS2Frame();
+            _currentDepthFrame = new RealSense2API.RS2Frame();
+            _currentLeftFrame = new RealSense2API.RS2Frame();
+            _currentRightFrame = new RealSense2API.RS2Frame();
 
             bool running = RealSense2API.PipelineRunning;
 

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -158,6 +158,12 @@ namespace MetriCam2.Cameras
             _depthScale = RealSense2API.GetDepthScale(_pipeline);
         }
 
+        public void RestartPipeline()
+        {
+            RealSense2API.PipelineStop(_pipeline);
+            RealSense2API.PipelineStart(_pipeline, _config);
+        }
+
         protected override void DisconnectImpl()
         {
             RealSense2API.PipelineStop(_pipeline);            
@@ -183,7 +189,7 @@ namespace MetriCam2.Cameras
             {
                 RealSense2API.RS2Frame data = RealSense2API.PipelineWaitForFrames(_pipeline, 500);
 
-                if(!data.IsValid())
+                if(!data.IsValid() || data.Handle == IntPtr.Zero)
                 {
                     RealSense2API.ReleaseFrame(data);
                     continue;
@@ -598,7 +604,7 @@ namespace MetriCam2.Cameras
         {
             RealSense2API.RS2Device dev = RealSense2API.GetActiveDevice(_pipeline);
             RealSense2API.LoadAdvancedConfig(json, dev);
-            RealSense2API.DeleteDevice(dev);
+            //RealSense2API.DeleteDevice(dev);
             _depthScale = RealSense2API.GetDepthScale(_pipeline);
         }
     }

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -145,14 +145,14 @@ namespace MetriCam2.Cameras
 
             RealSense2API.PipelineStart(_pipeline, _config);
 
-            //RealSense2API.RS2Device dev = RealSense2API.GetActiveDevice(_pipeline);
+            RealSense2API.RS2Device dev = RealSense2API.GetActiveDevice(_pipeline);
 
-            //if (!RealSense2API.AdvancedModeEnabled(dev))
-            //{
-            //    RealSense2API.EnabledAdvancedMode(dev, true);
-            //}
+            if (!RealSense2API.AdvancedModeEnabled(dev))
+            {
+                RealSense2API.EnabledAdvancedMode(dev, true);
+            }
 
-            //_depthScale = RealSense2API.GetDepthScale(_pipeline);
+            _depthScale = RealSense2API.GetDepthScale(_pipeline);
         }
 
         protected override void DisconnectImpl()

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -580,6 +580,11 @@ namespace MetriCam2.Cameras
 
         #endregion
 
+        public string GetFirmware()
+        {
+            return RealSense2API.GetFirmwareVersion(_pipeline);
+        }
+
         public void LoadConfigPreset(AdvancedMode.Preset preset)
         {
             LoadCustomConfig(AdvancedMode.GetPreset(preset));

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -155,12 +155,6 @@ namespace MetriCam2.Cameras
             _depthScale = RealSense2API.GetDepthScale(_pipeline);
         }
 
-        public void RestartPipeline()
-        {
-            RealSense2API.PipelineStop(_pipeline);
-            RealSense2API.PipelineStart(_pipeline, _config);
-        }
-
         protected override void DisconnectImpl()
         {
             if (!IsConnected)
@@ -189,7 +183,7 @@ namespace MetriCam2.Cameras
             {
                 RealSense2API.RS2Frame data = RealSense2API.PipelineWaitForFrames(_pipeline, 500);
 
-                if(!data.IsValid() || data.Handle == IntPtr.Zero)
+                if(!data.IsValid())
                 {
                     RealSense2API.ReleaseFrame(data);
                     continue;
@@ -600,7 +594,7 @@ namespace MetriCam2.Cameras
         {
             RealSense2API.RS2Device dev = RealSense2API.GetActiveDevice(_pipeline);
             RealSense2API.LoadAdvancedConfig(json, dev);
-            //RealSense2API.DeleteDevice(dev);
+            RealSense2API.DeleteDevice(dev);
             _depthScale = RealSense2API.GetDepthScale(_pipeline);
         }
     }

--- a/BetaCameras/RealSense2/RealSense2.csproj
+++ b/BetaCameras/RealSense2/RealSense2.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MetrilusReferencesVersions.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -10,13 +10,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MetriCam2.Cameras</RootNamespace>
     <AssemblyName>MetriCam2.Cameras.RealSense2</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +27,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>..\..\bin\x86\Release\</OutputPath>
@@ -40,7 +38,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -52,7 +49,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\..\bin\x64\Release\</OutputPath>
@@ -64,16 +60,10 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MetriCam2.NetStandard, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>Z:\releases\MetriCam2\R9.2\lib_netstandard2.0\MetriCam2.NetStandard.dll</HintPath>
-    </Reference>
-    <Reference Include="Metrilus.Util.NetStandard, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>Z:\releases\MetriCam2\R9.2\lib_netstandard2.0\Metrilus.Util.NetStandard.dll</HintPath>
+    <Reference Include="Metrilus.Util">
+      <HintPath>$(MetrilusUtilPath)Metrilus.Util.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -92,6 +82,12 @@
     <Compile Include="RealSense2.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RealSense2API.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MetriCam2\MetriCam2.csproj">
+      <Project>{342f049e-668b-4351-b21d-75e4bef5a1e4}</Project>
+      <Name>MetriCam2</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\.licenseheader">

--- a/BetaCameras/RealSense2/RealSense2.csproj
+++ b/BetaCameras/RealSense2/RealSense2.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MetrilusReferencesVersions.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -10,12 +10,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MetriCam2.Cameras</RootNamespace>
     <AssemblyName>MetriCam2.Cameras.RealSense2</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -27,6 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>..\..\bin\x86\Release\</OutputPath>
@@ -38,6 +40,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +52,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\..\bin\x64\Release\</OutputPath>
@@ -60,10 +64,16 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Metrilus.Util">
-      <HintPath>$(MetrilusUtilPath)Metrilus.Util.dll</HintPath>
+    <Reference Include="MetriCam2.NetStandard, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>Z:\releases\MetriCam2\R9.2\lib_netstandard2.0\MetriCam2.NetStandard.dll</HintPath>
+    </Reference>
+    <Reference Include="Metrilus.Util.NetStandard, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>Z:\releases\MetriCam2\R9.2\lib_netstandard2.0\Metrilus.Util.NetStandard.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -82,12 +92,6 @@
     <Compile Include="RealSense2.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RealSense2API.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\MetriCam2\MetriCam2.csproj">
-      <Project>{342f049e-668b-4351-b21d-75e4bef5a1e4}</Project>
-      <Name>MetriCam2</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\.licenseheader">

--- a/BetaCameras/RealSense2/RealSense2API.cs
+++ b/BetaCameras/RealSense2/RealSense2API.cs
@@ -14,6 +14,8 @@ namespace MetriCam2.Cameras
 
         private const int ApiVersion = API_MAJOR_VERSION * 10000 + API_MINOR_VERSION * 100 + API_PATCH_VERSION;
 
+        public static bool PipelineRunning { get; private set; } = false;
+
         public enum Format
         {
             ANY,             /* When passed to enable stream, librealsense will try to provide best suited format */
@@ -372,6 +374,8 @@ namespace MetriCam2.Cameras
             IntPtr error = IntPtr.Zero;
             rs2_pipeline_start_with_config(pipe.Handle, conf.Handle, &error);
             HandleError(error);
+
+            PipelineRunning = true;
         }
 
         unsafe public static void PipelineStop(RS2Pipeline pipe)
@@ -379,6 +383,8 @@ namespace MetriCam2.Cameras
             IntPtr error = IntPtr.Zero;
             rs2_pipeline_stop(pipe.Handle, &error);
             HandleError(error);
+
+            PipelineRunning = false;
         }
 
         unsafe public static void ReleaseFrame(RS2Frame frame)


### PR DESCRIPTION
- Don't stop pipeline twice on disposal
- Don't stop pipeline it it isn't already running
- Don't stop and restart pipeline on config changes if camera isn't connected yet
- Add call to retrieve firmware version from the camera (not actually used yet)