### PR TITLE
update RealSense2 API version to 2.9.0

### DIFF
--- a/BetaCameras/RealSense2/RealSense2API.cs
+++ b/BetaCameras/RealSense2/RealSense2API.cs
@@ -10,9 +10,9 @@ namespace MetriCam2.Cameras
     {
         // HINT: update API version to currently used librealsense2
         private const int API_MAJOR_VERSION = 2;
-        private const int API_MINOR_VERSION = 8;
+        private const int API_MINOR_VERSION = 9;
         private const int API_PATCH_VERSION = 0;
-        private const int API_BUILD_VERSION = 3;
+        private const int API_BUILD_VERSION = 0;
 
         private const int ApiVersion = API_MAJOR_VERSION * 10000 + API_MINOR_VERSION * 100 + API_PATCH_VERSION;
 


### PR DESCRIPTION
Discussion:
The realsense2 API performs a version check upon context creation. If the major and minor versions don't match the ones from the realsense2 library the API-call fails. Even if the used API didn't change at all. Bug fix releases should be compatible. So version 2.8.0 all the way up to 2.8.3 are compatible.
Right now the realsense releases are pretty frequent. So should we just keep up with them and update our code accordingly or stick to a known to work version and advise all colleagues to use the specified version?