### PR TITLE
Fix issue with multiple RealSense2 devices

### DIFF
--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1358,7 +1358,7 @@ namespace MetriCam2.Cameras
 
         private void StopPipeline()
         {
-            if (RealSense2API.PipelineRunning)
+            if (_pipeline.Running)
                 RealSense2API.PipelineStop(_pipeline);
             else
             {
@@ -1378,7 +1378,7 @@ namespace MetriCam2.Cameras
                 throw new InvalidOperationException(msg);
             }
 
-            if (RealSense2API.PipelineRunning)
+            if (_pipeline.Running)
                 RealSense2API.PipelineStop(_pipeline);
 
             RealSense2API.PipelineStart(_pipeline, _config);
@@ -1397,7 +1397,7 @@ namespace MetriCam2.Cameras
                 Thread.Sleep(50);
             }
 
-            if (!RealSense2API.PipelineRunning)
+            if (!_pipeline.Running)
             {
                 string msg = "RealSense2: Can't update camera since pipeline is not running";
                 log.Error(msg);
@@ -1577,7 +1577,7 @@ namespace MetriCam2.Cameras
                 throw new InvalidOperationException(msg);
             }
 
-            bool running = RealSense2API.PipelineRunning;
+            bool running = _pipeline.Running;
 
             if (running)
             {
@@ -1622,7 +1622,7 @@ namespace MetriCam2.Cameras
             _currentLeftFrame = new RealSense2API.RS2Frame();
             _currentRightFrame = new RealSense2API.RS2Frame();
 
-            bool running = RealSense2API.PipelineRunning;
+            bool running = _pipeline.Running;
             
 
             if (running)

--- a/BetaCameras/RealSense2/RealSense2API.cs
+++ b/BetaCameras/RealSense2/RealSense2API.cs
@@ -16,8 +16,6 @@ namespace MetriCam2.Cameras
 
         private const int ApiVersion = API_MAJOR_VERSION * 10000 + API_MINOR_VERSION * 100 + API_PATCH_VERSION;
 
-        public static bool PipelineRunning { get; private set; } = false;
-
         public struct SensorName
         {
             public const string COLOR = "RGB Camera";
@@ -630,8 +628,11 @@ namespace MetriCam2.Cameras
         {
             public IntPtr Handle { get; private set; }
 
+            public bool Running { get; set; }
+
             public RS2Pipeline(IntPtr p)
             {
+                Running = false;
                 Handle = p;
             }
 
@@ -863,7 +864,7 @@ namespace MetriCam2.Cameras
                 rs2_pipeline_start_with_config(pipe.Handle, conf.Handle, &error);
                 HandleError(error);
 
-                PipelineRunning = true;
+                pipe.Running = true;
             }
             catch (Exception)
             {
@@ -879,7 +880,7 @@ namespace MetriCam2.Cameras
                 rs2_pipeline_stop(pipe.Handle, &error);
                 HandleError(error);
 
-                PipelineRunning = false;
+                pipe.Running = false;
             }
             catch (Exception)
             {


### PR DESCRIPTION
refactor static `PipelineRunning` to property of the pipeline struct to avoid issues with multiple cameras