### PR TITLE
[RealSense2] Go back to version 2.8.3

### DIFF
--- a/BetaCameras/RealSense2/RealSense2API.cs
+++ b/BetaCameras/RealSense2/RealSense2API.cs
@@ -10,9 +10,9 @@ namespace MetriCam2.Cameras
     {
         // HINT: update API version to currently used librealsense2
         private const int API_MAJOR_VERSION = 2;
-        private const int API_MINOR_VERSION = 9;
+        private const int API_MINOR_VERSION = 8;
         private const int API_PATCH_VERSION = 0;
-        private const int API_BUILD_VERSION = 0;
+        private const int API_BUILD_VERSION = 3;
 
         private const int ApiVersion = API_MAJOR_VERSION * 10000 + API_MINOR_VERSION * 100 + API_PATCH_VERSION;
 


### PR DESCRIPTION
Calculating the color image broke with version 2.9.0. The official documentation doesn't state any relevant API changes. Retrieving the frame, reading the metadata and reading the first half of the image still works, so I don't think the issue is withing our code. I'm going to investigate this issue further and open up a bug report on the realsense project if necessary.