### PR TITLE
Hotfix

### DIFF
--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1568,8 +1568,26 @@ namespace MetriCam2.Cameras
                 fps = ColorFPS;
                 index = -1;
             }
-            else if (channelName == ChannelNames.ZImage)
+            else if (channelName == ChannelNames.ZImage
+                || channelName == ChannelNames.Distance)
             {
+                // Distance and ZImage channel access the same data from
+                // the realsense2 device
+                // so check if one of them was already active
+                // and skip activating the DEPTH stream in that case
+
+                if (channelName == ChannelNames.ZImage
+                    && IsChannelActive(ChannelNames.Distance))
+                {
+                    return;
+                }
+
+                if (channelName == ChannelNames.Distance
+                    && IsChannelActive(ChannelNames.ZImage))
+                {
+                    return;
+                }
+
                 stream = RealSense2API.Stream.DEPTH;
                 format = RealSense2API.Format.Z16;
 
@@ -1632,8 +1650,26 @@ namespace MetriCam2.Cameras
             {
                 stream = RealSense2API.Stream.COLOR;
             }
-            else if (channelName == ChannelNames.ZImage)
+            else if (channelName == ChannelNames.ZImage
+            || channelName == ChannelNames.Distance)
             {
+                // Distance and ZImage channel access the same data from
+                // the realsense2 device
+                // so check if one of them is still active
+                // and skip deactivating the DEPTH stream in that case
+
+                if (channelName == ChannelNames.ZImage
+                    && IsChannelActive(ChannelNames.Distance))
+                {
+                    return;
+                }
+
+                if (channelName == ChannelNames.Distance
+                    && IsChannelActive(ChannelNames.ZImage))
+                {
+                    return;
+                }
+
                 stream = RealSense2API.Stream.DEPTH;
             }
             else if (channelName == ChannelNames.Left)


### PR DESCRIPTION
Distance and ZImage channel use the same stream of the realsense2 device (DEPTH).
This should fix enabling the DEPTH stream again if either ZImage or Distance channel is already active and disabling the DEPTH stream if ZImage or Distance is still active.