### PR TITLE
Basler dispose camera

### DIFF
--- a/BetaCameras/BaslerToF/BaslerToF.cs
+++ b/BetaCameras/BaslerToF/BaslerToF.cs
@@ -193,7 +193,7 @@ namespace MetriCam2.Cameras
         /// Activate a channel.
         /// </summary>
         /// <param name="channelName">Channel name.</param>
-        /// <remarks>This method is implicitely called by <see cref="Camera.ActivateChannel"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.ActivateChannel"/> inside a camera lock.</remarks>
         protected override void ActivateChannelImpl(string channelName)
         {
             if (!IsConnected)
@@ -209,7 +209,7 @@ namespace MetriCam2.Cameras
         /// Deactivate a channel to save time in <see cref="Update"/>.
         /// </summary>
         /// <param name="channelName">Channel name.</param>
-        /// <remarks>This method is implicitely called by <see cref="Camera.DeactivateChannel"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.DeactivateChannel"/> inside a camera lock.</remarks>
         protected override void DeactivateChannelImpl(string channelName)
         {
             if (!IsConnected)
@@ -224,7 +224,7 @@ namespace MetriCam2.Cameras
         /// Device-specific implementation of Connect.
         /// Connects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Connect"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Connect"/> inside a camera lock.</remarks>
         /// <seealso cref="Camera.Connect"/>
         protected override void ConnectImpl()
         {
@@ -318,7 +318,7 @@ namespace MetriCam2.Cameras
         /// Device-specific implementation of Disconnect.
         /// Disconnects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Disconnect"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Disconnect"/> inside a camera lock.</remarks>
         /// <seealso cref="Camera.Disconnect"/>
         protected override void DisconnectImpl()
         {
@@ -332,7 +332,7 @@ namespace MetriCam2.Cameras
         /// Device-specific implementation of Update.
         /// Updates data buffers of all active channels with data of current frame.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Update"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Update"/> inside a camera lock.</remarks>
         /// <seealso cref="Camera.Update"/>
         protected override void UpdateImpl()
         {

--- a/BetaCameras/BaslerToF/BaslerToF.csproj
+++ b/BetaCameras/BaslerToF/BaslerToF.csproj
@@ -12,10 +12,6 @@
     <AssemblyName>MetriCam2.Cameras.BaslerToF</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -71,13 +67,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="ToFCameraWrapper, Version=1.0.6614.29978, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="ToFCameraWrapper">
       <HintPath>Z:\external-libraries\Basler\ToF Camera\v1.3.2.1322\ToFCameraWrapper.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/BetaCameras/Sick.VisionaryT/VisionaryT.cs
+++ b/BetaCameras/Sick.VisionaryT/VisionaryT.cs
@@ -8,7 +8,7 @@ using MetriCam2.Cameras.Internal.Sick;
 namespace MetriCam2.Cameras
 {
     /// <summary>
-    /// MetriCam2 Wrapper for V3S100 Cameras.
+    /// MetriCam2 wrapper for Sick V3S100 cameras.
     /// </summary>
     public class VisionaryT : Camera
     {
@@ -173,7 +173,7 @@ namespace MetriCam2.Cameras
         /// <summary>
         /// Connects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Connect"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Connect"/> inside a camera lock.</remarks>
         protected override void ConnectImpl()
         {
             if (ipAddress == null || ipAddress == "")
@@ -224,7 +224,7 @@ namespace MetriCam2.Cameras
         /// <summary>
         /// Disconnects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Disconnect"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Disconnect"/> inside a camera lock.</remarks>
         protected override void DisconnectImpl()
         {
             device.Control_StopStream();
@@ -235,7 +235,7 @@ namespace MetriCam2.Cameras
         /// <summary>
         /// Updates data buffers of all channels with data of current frame.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Update"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Update"/> inside a camera lock.</remarks>
         protected override void UpdateImpl()
         {
             imageBuffer = device.Stream_GetFrame();

--- a/BetaCameras/ifm/O3D3xx.cs
+++ b/BetaCameras/ifm/O3D3xx.cs
@@ -16,17 +16,8 @@ using System.Threading;
 namespace MetriCam2.Cameras
 {
     /// <summary>
-    /// This is a template for creating new camera wrappers, and also a dummy camera.
+    /// MetriCam2 Wrapper for ifm O3D3xx cameras.
     /// </summary>
-    /// <remarks>
-    /// Follow this guide if you want to add a new camera implementation:
-    /// 1. Start by reading @link page_adding_a_new_camera Adding a new camera @endlink.
-    /// 2. Delete this how-to and anything named DEMO or DUMMY.
-    /// 3. Add MetriCam2 to the project's references.
-    /// 4. Implement Camera's methods.
-    /// 5. Work through all comments and update them (i.e. remove remarks like "This method is implicitely called [...]" and "Device-specific implementation of [...]").
-    /// 6. (optional) Implement ActivateChannelImpl and DeactivateChannelImpl.
-    /// </remarks>
     public class O3D3xx : Camera
     {
         [DllImport("iphlpapi.dll")]
@@ -258,7 +249,7 @@ namespace MetriCam2.Cameras
         /// Device-specific implementation of Connect.
         /// Connects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Connect"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Connect"/> inside a camera lock.</remarks>
         /// <seealso cref="Camera.Connect"/>
         protected override void ConnectImpl()
         {
@@ -458,7 +449,7 @@ namespace MetriCam2.Cameras
         /// Device-specific implementation of Disconnect.
         /// Disconnects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Disconnect"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Disconnect"/> inside a camera lock.</remarks>
         /// <seealso cref="Camera.Disconnect"/>
         protected override void DisconnectImpl()
         {
@@ -469,7 +460,7 @@ namespace MetriCam2.Cameras
         /// Device-specific implementation of Update.
         /// Updates data buffers of all active channels with data of current frame.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Update"/> inside a camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Update"/> inside a camera lock.</remarks>
         /// <seealso cref="Camera.Update"/>
         protected override void UpdateImpl()
         {

--- a/MetriCam2/Camera.cs
+++ b/MetriCam2/Camera.cs
@@ -2465,19 +2465,19 @@ namespace MetriCam2
         /// Device-specific implementation of <see cref="Connect"/>.
         /// Connects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Connect"/> inside the camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Connect"/> inside the camera lock.</remarks>
         protected abstract void ConnectImpl();
         /// <summary>
         /// Device-specific implementation of <see cref="Disconnect"/>.
         /// Disconnects the camera.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Disconnect"/> (usually inside the camera lock).</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Disconnect"/> (usually inside the camera lock).</remarks>
         protected abstract void DisconnectImpl();
         /// <summary>
         /// Device-specific implementation of <see cref="Update"/>.
         /// Updates data buffers of all active channels with data of current frame.
         /// </summary>
-        /// <remarks>This method is implicitely called by <see cref="Camera.Update"/> inside the camera lock.</remarks>
+        /// <remarks>This method is implicitly called by <see cref="Camera.Update"/> inside the camera lock.</remarks>
         protected abstract void UpdateImpl();
         /// <summary>
         /// Device-specific implementation of <see cref="ActivateChannel"/>.
@@ -2486,7 +2486,7 @@ namespace MetriCam2
         /// <param name="channelName">Channel name.</param>
         /// <remarks>
         /// Depending on the underlying camera, the channel stream may be created / registered in this method.
-        /// This method is implicitely called by <see cref="Camera.ActivateChannel"/> inside the camera lock.
+        /// This method is implicitly called by <see cref="Camera.ActivateChannel"/> inside the camera lock.
         /// </remarks>
         protected virtual void ActivateChannelImpl(string channelName)
         {
@@ -2499,7 +2499,7 @@ namespace MetriCam2
         /// <param name="channelName">Channel name.</param>
         /// <remarks>
         /// Depending on the underlying camera, the channel stream may be destroyed / unregistered in this method.
-        /// This method is implicitely called by <see cref="Camera.DeactivateChannel"/> inside the camera lock.
+        /// This method is implicitly called by <see cref="Camera.DeactivateChannel"/> inside the camera lock.
         /// </remarks>
         protected virtual void DeactivateChannelImpl(string channelName)
         {
@@ -2510,7 +2510,7 @@ namespace MetriCam2
         /// <param name="channelName">Channel name.</param>
         /// <returns>(Image) Data.</returns>
         /// <remarks>
-        /// This method is implicitely called by <see cref="Camera.CalcChannel"/>, non-locked.
+        /// This method is implicitly called by <see cref="Camera.CalcChannel"/>, non-locked.
         /// If your implementation needs locking, use <see cref="Camera.cameraLock"/>.
         /// </remarks>
         protected abstract CameraImage CalcChannelImpl(string channelName);


### PR DESCRIPTION
Dispose the `ToFCamera` object on Disconnect - and create it in Connect, not in the c'tor.

Rest is cleaning up stuff. I suggest going thru commit by commit, then the relevant stuff is easily recognizable.