### PR TITLE
[RealSense2] fix extrinsics

### DIFF
--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1769,8 +1769,6 @@ namespace MetriCam2.Cameras
                 .Where(p => p.Width == refResolution.X && p.Height == refResolution.Y)
                 .Where(p => p.Index == index)
                 .First();
-
-            throw new ArgumentException(string.Format("{0}: stream profile for channel {1} with resolution {2}x{3} not available", Name, channelName, refResolution.X, refResolution.Y));
         }
 
         unsafe public override RigidBodyTransformation GetExtrinsics(string channelFromName, string channelToName)

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1726,6 +1726,7 @@ namespace MetriCam2.Cameras
                     streamType = Stream.Color;
                     break;
                 case ChannelNames.ZImage:
+                case ChannelNames.Distance:
                     sensorName = SensorNames.Stereo;
                     streamType = Stream.Depth;
                     refResolution = DepthResolution;
@@ -1745,7 +1746,6 @@ namespace MetriCam2.Cameras
                     refFPS = DepthFPS;
                     index = 2;
                     break;
-                case ChannelNames.Distance:
                 default:
                     string msg = string.Format("RealSense2: stream profile for channel {0} not available", channelName);
                     log.Error(msg);


### PR DESCRIPTION
Save handle to device as member of the camera.
Otherwise when getting the 2 videoprofiles for the extrinsics
we'd have a different handle to the device for each profile.
This would cause an error when getting the extrinsics with the
message that no transformation between the two profiles is available.