### PR TITLE
[RealSense2] Workaround for temparture properties

### DIFF
--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1187,23 +1187,23 @@ namespace MetriCam2.Cameras
         {
             get
             {
-                CheckOptionSupported(Option.ProjectorTemperature, ProjectorTempDesc.Name, SensorNames.Stereo);
+                CheckOptionSupported(Option.ProjectorTemperature, nameof(ProjectorTemp), SensorNames.Stereo);
                 return GetOption(SensorNames.Stereo, Option.ProjectorTemperature);
             }
         }
 
-        ParamDesc<float> ProjectorTempDesc
-        {
-            get
-            {
-                ParamDesc<float> res = new ParamDesc<float>();
-                res.Unit = "°C";
-                res.Description = "Projector Temperature";
-                res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
-                res.WritableWhen = ParamDesc.ConnectionStates.Connected;
-                return res;
-            }
-        }
+        //ParamDesc<float> ProjectorTempDesc
+        //{
+        //    get
+        //    {
+        //        ParamDesc<float> res = new ParamDesc<float>();
+        //        res.Unit = "°C";
+        //        res.Description = "Projector Temperature";
+        //        res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
+        //        res.WritableWhen = ParamDesc.ConnectionStates.Connected;
+        //        return res;
+        //    }
+        //}
 
 
         /// <summary>

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1130,23 +1130,27 @@ namespace MetriCam2.Cameras
         {
             get
             {
+                // Workaround: open and start up depthsensor
+                OpenDepthSensor();
                 CheckOptionSupported(Option.AsicTemperature, nameof(ASICTemp), SensorNames.Stereo);
-                return GetOption(SensorNames.Stereo, Option.AsicTemperature);
+                float temp = GetOption(SensorNames.Stereo, Option.AsicTemperature);
+                CloseDepthSensor();
+                return temp;
             }
         }
 
-        //ParamDesc<float> ASICTempDesc
-        //{
-        //    get
-        //    {
-        //        ParamDesc<float> res = new ParamDesc<float>();
-        //        res.Unit = "°C";
-        //        res.Description = "Asic Temperature";
-        //        res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
-        //        res.WritableWhen = ParamDesc.ConnectionStates.Connected;
-        //        return res;
-        //    }
-        //}
+        ParamDesc<float> ASICTempDesc
+        {
+            get
+            {
+                ParamDesc<float> res = new ParamDesc<float>();
+                res.Unit = "°C";
+                res.Description = "Asic Temperature";
+                res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
+                res.WritableWhen = ParamDesc.ConnectionStates.Connected;
+                return res;
+            }
+        }
 
 
         /// <summary>
@@ -1187,23 +1191,28 @@ namespace MetriCam2.Cameras
         {
             get
             {
+                // Workaround
+                OpenDepthSensor();
                 CheckOptionSupported(Option.ProjectorTemperature, nameof(ProjectorTemp), SensorNames.Stereo);
-                return GetOption(SensorNames.Stereo, Option.ProjectorTemperature);
+                float temp = GetOption(SensorNames.Stereo, Option.ProjectorTemperature);
+                CloseDepthSensor();
+
+                return temp;
             }
         }
 
-        //ParamDesc<float> ProjectorTempDesc
-        //{
-        //    get
-        //    {
-        //        ParamDesc<float> res = new ParamDesc<float>();
-        //        res.Unit = "°C";
-        //        res.Description = "Projector Temperature";
-        //        res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
-        //        res.WritableWhen = ParamDesc.ConnectionStates.Connected;
-        //        return res;
-        //    }
-        //}
+        ParamDesc<float> ProjectorTempDesc
+        {
+            get
+            {
+                ParamDesc<float> res = new ParamDesc<float>();
+                res.Unit = "°C";
+                res.Description = "Projector Temperature";
+                res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
+                res.WritableWhen = ParamDesc.ConnectionStates.Connected;
+                return res;
+            }
+        }
 
 
         /// <summary>
@@ -2015,12 +2024,26 @@ namespace MetriCam2.Cameras
 
         private float GetDepthScale()
         {
-            Sensor depthSensor = GetSensor(SensorNames.Stereo);
-            depthSensor.Open();
-            float depthScale = depthSensor.DepthScale;
-            depthSensor.Close();
+            OpenDepthSensor();
+            float depthScale = GetSensor(SensorNames.Stereo).DepthScale;
+            CloseDepthSensor();
 
             return depthScale;
+        }
+
+        private void OpenDepthSensor()
+        {
+            var depthSensor = GetSensor(SensorNames.Stereo);
+            FrameQueue q = new FrameQueue();
+            depthSensor.Open();
+            depthSensor.Start(q);
+        }
+
+        private void CloseDepthSensor()
+        {
+            var depthSensor = GetSensor(SensorNames.Stereo);
+            depthSensor.Stop();
+            depthSensor.Close();
         }
     }
 }

--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1130,23 +1130,23 @@ namespace MetriCam2.Cameras
         {
             get
             {
-                CheckOptionSupported(Option.AsicTemperature, ASICTempDesc.Name, SensorNames.Stereo);
+                CheckOptionSupported(Option.AsicTemperature, nameof(ASICTemp), SensorNames.Stereo);
                 return GetOption(SensorNames.Stereo, Option.AsicTemperature);
             }
         }
 
-        ParamDesc<float> ASICTempDesc
-        {
-            get
-            {
-                ParamDesc<float> res = new ParamDesc<float>();
-                res.Unit = "°C";
-                res.Description = "Asic Temperature";
-                res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
-                res.WritableWhen = ParamDesc.ConnectionStates.Connected;
-                return res;
-            }
-        }
+        //ParamDesc<float> ASICTempDesc
+        //{
+        //    get
+        //    {
+        //        ParamDesc<float> res = new ParamDesc<float>();
+        //        res.Unit = "°C";
+        //        res.Description = "Asic Temperature";
+        //        res.ReadableWhen = ParamDesc.ConnectionStates.Connected;
+        //        res.WritableWhen = ParamDesc.ConnectionStates.Connected;
+        //        return res;
+        //    }
+        //}
 
 
         /// <summary>


### PR DESCRIPTION
Workaround:
Open and start the depth sensor before querying Asic- or ProjectorTemperature.
This seems a bit counter-intuitive to me as using a pipeline should handle all the low level fiddling with sensors.
I opened up an [issue](https://github.com/IntelRealSense/librealsense/issues/1410) asking if the workaround is necessary or if it is indeed a bug in their software.

edit: the issue was clarified by an intel developer. Proper fix is implemented now.