### PR TITLE
[RealSense2] check realsense config before attempting to start the pipeline

### DIFF
--- a/BetaCameras/RealSense2/RealSense2.cs
+++ b/BetaCameras/RealSense2/RealSense2.cs
@@ -1478,18 +1478,22 @@ namespace MetriCam2.Cameras
 
         private void StartPipeline()
         {
-
-            if (!_config.CanResolve(_pipeline))
-            {
-                string msg = $"{Name}: current combination of settings is not supported";
-                log.Error(msg);
-                throw new SettingsCombinationNotSupportedException(msg);
-            }
+            CheckConfig();
 
             if (!_pipelineRunning)
             {
                 _pipelineProfile = _pipeline.Start(_config);
                 _pipelineRunning = true;
+            }
+        }
+
+        private void CheckConfig()
+        {
+            if (!_config.CanResolve(_pipeline))
+            {
+                string msg = $"{Name}: current combination of settings is not supported";
+                log.Error(msg);
+                throw new SettingsCombinationNotSupportedException(msg);
             }
         }
 
@@ -2092,9 +2096,11 @@ namespace MetriCam2.Cameras
                 DeactivateChannels(channelNames);
                 property = newValue;
                 ActivateChannels(channelNames);
+                CheckConfig();
             }
             catch (SettingsCombinationNotSupportedException)
             {
+                DeactivateChannels(channelNames);
                 property = oldValue;
                 ActivateChannels(channelNames);
                 throw;


### PR DESCRIPTION
Unfortunately I still managed to make the MetriCam2 Settings UI misbehave when testing with the changes of #118.
It was possible for the `SettingsCombinationNotSupportedException` to only be thrown when already in the `finally` block. This leads to the `catch` block not being executed when it is thrown there and the property is not reset to it's old value. Then next time the pipeline tries to start it can't because the unsupported combination of settings is still applied.
Checking the config and throwing the exception before starting the pipeline in case of an invalid configuration fixes the problem.