### PR TITLE
Support loading cam assemblies from working folder

### DIFF
--- a/MetriCam2/CameraManagement.cs
+++ b/MetriCam2/CameraManagement.cs
@@ -282,6 +282,12 @@ namespace MetriCam2
                 return;
             }
 
+            if (!Path.IsPathRooted(filename))
+            {
+                filename = Path.GetFullPath(filename);
+                log.DebugFormat("Updated filename to absolute path: '{0}'.", filename);
+            }
+
             Assembly assembly = null;
 
             try


### PR DESCRIPTION
`Assembly.LoadFile` requires an absolute path. Now, `ScanAssembly` can be called with just the assembly name and will succeed if the assembly is in the apps working dir.