### PR TITLE
Fix NRE and compile errors in Sick Visionary-T implementation

### DIFF
--- a/BetaCameras/Sick.VisionaryT/Device.cs
+++ b/BetaCameras/Sick.VisionaryT/Device.cs
@@ -48,8 +48,9 @@ namespace MetriCam2.Cameras.Internal.Sick
             }
             catch (Exception ex)
             {
-                log.ErrorFormat("Failed to connect to IP={0}, reasons={1}", ipAddress, ex.Message);
-                ExceptionBuilder.Throw(ex.GetType(), cam, ex);
+                string msg = string.Format("{0}: Failed to connect to IP {1}{2}Reason: {3}", cam.Name, ipAddress, Environment.NewLine, ex.Message);
+                log.Error(msg);
+                throw new Exceptions.ConnectionFailedException(msg, ex);
             }
 
             streamData = sockData.GetStream();

--- a/BetaCameras/Sick.VisionaryT/FrameData.cs
+++ b/BetaCameras/Sick.VisionaryT/FrameData.cs
@@ -222,7 +222,7 @@ namespace MetriCam2.Cameras.Internal.Sick
             }
             else
             {
-                string msg = string.Format("{0}: Bytes per distance value has unexpected value \"{1}\"", dataType);
+                string msg = string.Format("{0}: Bytes per distance value has unexpected value \"{1}\"", cam.Name, dataType);
                 log.Error(msg);
                 throw new InvalidDataException(msg);
             }
@@ -234,7 +234,7 @@ namespace MetriCam2.Cameras.Internal.Sick
             }
             else
             {
-                string msg = string.Format("{0}: Bytes per intensity value has unexpected value \"{1}\"", dataType);
+                string msg = string.Format("{0}: Bytes per intensity value has unexpected value \"{1}\"", cam.Name, dataType);
                 log.Error(msg);
                 throw new InvalidDataException(msg);
             }
@@ -246,7 +246,7 @@ namespace MetriCam2.Cameras.Internal.Sick
             }
             else
             {
-                string msg = string.Format("{0}: Bytes per confidence value has unexpected value \"{1}\"", dataType);
+                string msg = string.Format("{0}: Bytes per confidence value has unexpected value \"{1}\"", cam.Name, dataType);
                 log.Error(msg);
                 throw new InvalidDataException(msg);
             }


### PR DESCRIPTION
1. `ExceptionBuilder.Throw(ex.GetType()` would throw a `NullReferenceException`. Since `ExceptionBuilder` sucks anyways I chose to throw an exception straight.

1. The compile errors in `FrameData.cs` might be due to a stricter VS version, but they were bugs all the time.