### PR TITLE
Remove ExceptionBuilder.Throw methods

### DIFF
--- a/BetaCameras/BaslerToF/BaslerToF.cs
+++ b/BetaCameras/BaslerToF/BaslerToF.cs
@@ -91,8 +91,7 @@ namespace MetriCam2.Cameras
                 var desc = DeviceChannelDesc;
                 if (!desc.IsValid(value))
                 {
-                    ExceptionBuilder.Throw(typeof(ArgumentOutOfRangeException), this, "error_setParameter", String.Format("The device channel must be between {0} and {1}.", desc.Min, desc.Max));
-                    return;
+                    throw ExceptionBuilder.Build(typeof(ArgumentOutOfRangeException), Name, "error_setParameter", String.Format("The device channel must be between {0} and {1}.", desc.Min, desc.Max));
                 }
 
                 if (!IsConnected)
@@ -131,8 +130,7 @@ namespace MetriCam2.Cameras
                 var desc = ExposureDesc;
                 if (!desc.IsValid(value))
                 {
-                    ExceptionBuilder.Throw(typeof(ArgumentOutOfRangeException), this, "error_setParameter", String.Format("The exposure time must be between {0} and {1} ms.", desc.Min, desc.Max));
-                    return;
+                    throw ExceptionBuilder.Build(typeof(ArgumentOutOfRangeException), Name, "error_setParameter", String.Format("The exposure time must be between {0} and {1} ms.", desc.Min, desc.Max));
                 }
 
                 exposureMilliseconds = value;

--- a/BetaCameras/RealSense/F200.cs
+++ b/BetaCameras/RealSense/F200.cs
@@ -221,8 +221,7 @@ namespace MetriCam2.Cameras
                     return irImage;
             }
 
-            ExceptionBuilder.Throw(typeof(ArgumentException), this, "error_invalidChannelName", channelName);
-            return null;
+            throw ExceptionBuilder.Build(typeof(ArgumentException), Name, "error_invalidChannelName", channelName);
         }
         #endregion
 

--- a/BetaCameras/RealSense/R200.cs
+++ b/BetaCameras/RealSense/R200.cs
@@ -127,7 +127,7 @@ namespace MetriCam2.Cameras
             if (deviceInfo.Count == 0)
             {
                 log.Error(Name + ": No devices found.");
-                ExceptionBuilder.Throw(typeof(ConnectionFailedException), this, "No devices found.");
+                throw ExceptionBuilder.Build(typeof(ConnectionFailedException), Name, "No devices found.");
             }
 
             int deviceIdx;
@@ -145,7 +145,7 @@ namespace MetriCam2.Cameras
             if (deviceIdx >= deviceInfo.Count)
             {
                 log.Error("Failed to find Intel Real Sense R200 camera!");
-                ExceptionBuilder.Throw(typeof(ConnectionFailedException), this, "No R200 found!");
+                throw ExceptionBuilder.Build(typeof(ConnectionFailedException), Name, "No R200 found!");
             }
 
             ScanForProfiles(deviceIdx);
@@ -166,7 +166,7 @@ namespace MetriCam2.Cameras
             if (retStat < pxcmStatus.PXCM_STATUS_NO_ERROR)
             {
                 log.Error(Name + ": Init() failed.");
-                ExceptionBuilder.Throw(typeof(ConnectionFailedException), this, "Failed to Initialize Real Sense SDK");
+                throw ExceptionBuilder.Build(typeof(ConnectionFailedException), Name, "Failed to Initialize Real Sense SDK");
             }
 
             pp.captureManager.device.ResetProperties(PXCMCapture.StreamType.STREAM_TYPE_ANY);
@@ -293,8 +293,7 @@ namespace MetriCam2.Cameras
                     return colorImage;
             }
 
-            ExceptionBuilder.Throw(typeof(ArgumentException), this, "error_invalidChannelName", channelName);
-            return null;
+            throw ExceptionBuilder.Build(typeof(ArgumentException), Name, "error_invalidChannelName", channelName);
         }
 
         public override RigidBodyTransformation GetExtrinsics(string channelFromName, string channelToName)

--- a/BetaCameras/SVS/SVS.cs
+++ b/BetaCameras/SVS/SVS.cs
@@ -132,7 +132,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_getAcquisitionMode(hCamera, ref value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameter", "AcquisitionMode: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameter", "AcquisitionMode: " + error.ToString());
                 }
                 return value;
             }
@@ -144,7 +144,7 @@ namespace MetriCam2.Cameras
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
                     log.ErrorFormat("{0}: Could not set AcquisitionMode to {1}. {2}", Name, value.ToString(), error.ToString());
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "AcquisitionMode: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "AcquisitionMode: " + error.ToString());
                 }
 
                 if (GigeApi.ACQUISITION_MODE.ACQUISITION_MODE_EXT_TRIGGER_EXT_EXPOSURE == value
@@ -181,7 +181,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_getAutoGainEnabled(hCamera, ref value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameter", "AutoGainEnabled: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameter", "AutoGainEnabled: " + error.ToString());
                 }
                 return value;
             }
@@ -191,7 +191,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_setAutoGainEnabled(hCamera, value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "AutoGainEnabled: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "AutoGainEnabled: " + error.ToString());
                 }
             }
         }
@@ -264,17 +264,17 @@ namespace MetriCam2.Cameras
                     error = gigeApi.Gige_Camera_getExposureTimeMin(hCamera, ref min);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameterValues", "ExposureTime.Min: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameterValues", "ExposureTime.Min: " + error.ToString());
                     }
                     error = gigeApi.Gige_Camera_getExposureTimeMax(hCamera, ref max);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameterValues", "ExposureTime.Max: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameterValues", "ExposureTime.Max: " + error.ToString());
                     }
                     error = gigeApi.Gige_Camera_getExposureTimeIncrement(hCamera, ref increment);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameterValues", "ExposureTime.Increment: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameterValues", "ExposureTime.Increment: " + error.ToString());
                     }
                 }
 
@@ -300,7 +300,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_getExposureTime(hCamera, ref value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameter", "ExposureTime: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameter", "ExposureTime: " + error.ToString());
                 }
                 return value * 0.001f;
             }
@@ -311,12 +311,12 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_setAutoExposureLimits(hCamera, value_ms, value_ms);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "AutoExposureLimits: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "AutoExposureLimits: " + error.ToString());
                 }
                 error = gigeApi.Gige_Camera_setExposureTime(hCamera, value_ms);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "ExposureTime: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "ExposureTime: " + error.ToString());
                 }
             }
         }
@@ -335,12 +335,12 @@ namespace MetriCam2.Cameras
                     error = gigeApi.Gige_Camera_getFrameRateRange(hCamera, ref min, ref max);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameterValues", "FrameRate.Range: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameterValues", "FrameRate.Range: " + error.ToString());
                     }
                     error = gigeApi.Gige_Camera_getFrameRateIncrement(hCamera, ref increment);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameterValues", "FrameRate.Increment: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameterValues", "FrameRate.Increment: " + error.ToString());
                     }
                 }
 
@@ -366,7 +366,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_getFrameRate(hCamera, ref value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameter", "FrameRate: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameter", "FrameRate: " + error.ToString());
                 }
                 return value;
             }
@@ -376,7 +376,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_setFrameRate(hCamera, value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "FrameRate: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "FrameRate: " + error.ToString());
                 }
             }
         }
@@ -395,12 +395,12 @@ namespace MetriCam2.Cameras
                     error = gigeApi.Gige_Camera_getGainMax(hCamera, ref max);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameterValues", "Gain.Max: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameterValues", "Gain.Max: " + error.ToString());
                     }
                     error = gigeApi.Gige_Camera_getGainIncrement(hCamera, ref increment);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameterValues", "Gain.Increment: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameterValues", "Gain.Increment: " + error.ToString());
                     }
                 }
 
@@ -427,7 +427,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_getGain(hCamera, ref value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameter", "Gain: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameter", "Gain: " + error.ToString());
                 }
                 return value;
             }
@@ -437,7 +437,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_setGain(hCamera, value);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "Gain: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "Gain: " + error.ToString());
                 }
             }
         }
@@ -470,7 +470,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_getWhiteBalance(hCamera, ref r, ref g, ref b);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_getParameter", "WhiteBalance: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_getParameter", "WhiteBalance: " + error.ToString());
                 }
                 return new Point3f(r, g, b);
             }
@@ -480,7 +480,7 @@ namespace MetriCam2.Cameras
                 error = gigeApi.Gige_Camera_setWhiteBalance(hCamera, value.X, value.Y, value.Z);
                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                 {
-                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "WhiteBalance: " + error.ToString());
+                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "WhiteBalance: " + error.ToString());
                 }
             }
         }
@@ -554,7 +554,7 @@ namespace MetriCam2.Cameras
                                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                                     {
                                         log.ErrorFormat("    Could not set PixelDepth to 12bpp: {0}", error.ToString());
-                                        ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "PixelDepth: " + error.ToString());
+                                        throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "PixelDepth: " + error.ToString());
                                     }
                                 }
                                 bitCount = 12;
@@ -570,7 +570,7 @@ namespace MetriCam2.Cameras
                                 if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                                 {
                                     log.ErrorFormat("    Could not set PixelDepth to 8bpp: {0}", error.ToString());
-                                    ExceptionBuilder.Throw(typeof(Exception), this, "error_setParameter", "PixelDepth: " + error.ToString());
+                                    throw ExceptionBuilder.Build(typeof(Exception), Name, "error_setParameter", "PixelDepth: " + error.ToString());
                                 }
                                 bitCount = 8;
                             }
@@ -686,17 +686,17 @@ namespace MetriCam2.Cameras
             container = gigeApi.Gige_CameraContainer_create(GigeApi.SVGigETL_Type.SVGigETL_TypeFilter);
             if (container < 0)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "ContainerCreate failed");
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "ContainerCreate failed");
             }
             error = gigeApi.Gige_CameraContainer_discovery(container);
             if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Camera discovery failed: " + error.ToString());
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Camera discovery failed: " + error.ToString());
             }
             numCameras = gigeApi.Gige_CameraContainer_getNumberOfCameras(container);
             if (numCameras <= 0)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "No cameras found.");
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "No cameras found.");
             }
             log.DebugFormat("    found {0} cameras", numCameras);
 
@@ -746,7 +746,7 @@ namespace MetriCam2.Cameras
             // check if connection was successful
             if (IntPtr.Zero == hCamera)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Failed to open connection to camera");
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Failed to open connection to camera");
             }
             log.InfoFormat("    connected to camera with serial number {0}", SerialNumber);
 
@@ -754,7 +754,7 @@ namespace MetriCam2.Cameras
             error = CreateStreamingChannel();
             if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Failed to create stream: " + error.ToString());
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Failed to create stream: " + error.ToString());
             }
 
             // Register log message callback
@@ -772,7 +772,7 @@ namespace MetriCam2.Cameras
                     error = gigeApi.Gige_Camera_registerForLogMessages(hCamera, LogLevel, LogFilename: "", LogCallback: logMessageCallbackDelegate, MessageContext: IntPtr.Zero);
                     if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
                     {
-                        ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Failed to register for log messages from camera: " + error.ToString());
+                        throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Failed to register for log messages from camera: " + error.ToString());
                     }
                 }
             }
@@ -781,7 +781,7 @@ namespace MetriCam2.Cameras
             if (gigeApi.Gige_Camera_getSizeX(hCamera, ref width) != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS ||
                 gigeApi.Gige_Camera_getSizeY(hCamera, ref height) != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Failed to get width and/or height of current stream");
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Failed to get width and/or height of current stream");
             }
             log.DebugFormat("    resolution is {0}x{1}", width, height);
 
@@ -790,7 +790,7 @@ namespace MetriCam2.Cameras
             error = gigeApi.Gige_Camera_getPixelDepth(hCamera, ref pixelDepth);
             if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Failed to get pixel depth: " + error.ToString());
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Failed to get pixel depth: " + error.ToString());
             }
             switch (pixelDepth)
             {
@@ -804,8 +804,7 @@ namespace MetriCam2.Cameras
                     bitCount = 16;
                     break;
                 default:
-                    ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Unsupported pixel depth");
-                    break;
+                    throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Unsupported pixel depth");
             }
             log.DebugFormat("    pixel depth is {0}", pixelDepth.ToString());
 
@@ -813,7 +812,7 @@ namespace MetriCam2.Cameras
             error = GetPixelType();
             if (error != GigeApi.SVSGigeApiReturn.SVGigE_SUCCESS)
             {
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", "Failed to get pixel type: " + error.ToString());
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "Failed to get pixel type: " + error.ToString());
             }
             log.DebugFormat("    pixel type is {0}", pixelType.ToString());
 

--- a/BetaCameras/Sick.TiM561/TiM561.cs
+++ b/BetaCameras/Sick.TiM561/TiM561.cs
@@ -143,7 +143,7 @@ namespace MetriCam2.Cameras
                         }
                         else
                         {
-                            ExceptionBuilder.Throw(typeof(ConnectionFailedException), this, "error_connectionFailed", "CoLa (binary) telegram subscription failed");
+                            throw ExceptionBuilder.Build(typeof(ConnectionFailedException), Name, "error_connectionFailed", "CoLa (binary) telegram subscription failed");
                         }
                     }
                     catch
@@ -178,7 +178,7 @@ namespace MetriCam2.Cameras
             catch (Exception foreignException)
             {
                 // Wrap and Throw other exceptions encountered during Connection
-                ExceptionBuilder.Throw(typeof(ConnectionFailedException), this, foreignException);
+                throw ExceptionBuilder.Build(typeof(ConnectionFailedException), Name, foreignException.Message, foreignException);
             }
         }
 
@@ -282,7 +282,7 @@ namespace MetriCam2.Cameras
             catch (Exception foreignException)
             {
                 // Wrap and Throw other exceptions encountered during Connection
-                ExceptionBuilder.Throw(typeof(ImageAcquisitionFailedException), this, foreignException);
+                throw ExceptionBuilder.Build(typeof(ImageAcquisitionFailedException), Name, foreignException.Message, foreignException);
             }
         }
 
@@ -350,7 +350,7 @@ namespace MetriCam2.Cameras
 
             string msg = $"{Name}: Invalid channelname: {channelName}";
             log.Error(msg);
-            throw ExceptionBuilder.Build(typeof(InvalidOperationException), this, msg);
+            throw ExceptionBuilder.Build(typeof(InvalidOperationException), Name, msg);
         }
 
         #region Channel Information

--- a/BetaCameras/Sick.VisionaryT/VisionaryT.cs
+++ b/BetaCameras/Sick.VisionaryT/VisionaryT.cs
@@ -200,7 +200,7 @@ namespace MetriCam2.Cameras
             {
                 string msg = string.Format("IP address is not set. It must be set before connecting.");
                 log.Error(msg);
-                ExceptionBuilder.Throw(typeof(Exceptions.ConnectionFailedException), this, "error_connectionFailed", msg);
+                throw ExceptionBuilder.Build(typeof(ConnectionFailedException), Name, "error_connectionFailed", msg);
             }
             device = new Device(ipAddress, this, log);
 

--- a/BetaCameras/TIVoxel/TIVoxel.cpp
+++ b/BetaCameras/TIVoxel/TIVoxel.cpp
@@ -31,8 +31,7 @@ void TIVoxel::ConnectImpl()
 			size_t numDevices = devices.size();
 			if (numDevices == 0)
 			{
-				ExceptionBuilder::Throw(MetriCam2::Exceptions::ConnectionFailedException::typeid, this, "error_connectionFailed", "No devices found.");
-				return;
+				throw ExceptionBuilder::Build(MetriCam2::Exceptions::ConnectionFailedException::typeid, Name, "error_connectionFailed", "No devices found.");
 			}
 			Voxel::DevicePtr toConnect;
 			for (int i = 0; i < numDevices; i++)
@@ -59,8 +58,7 @@ void TIVoxel::ConnectImpl()
 		}
 		if (cam == NULL || !(cam->isInitialized()))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ConnectionFailedException::typeid, this, "error_connectionFailed", "Failed to open camera.");
-			return;
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ConnectionFailedException::typeid, Name, "error_connectionFailed", "Failed to open camera.");
 		}
 		
 		this->SerialNumber = marshal_as<String^>((device)->serialNumber());
@@ -97,13 +95,9 @@ void TIVoxel::ConnectImpl()
 		{
 			log->Error("Could not register callback.");
 			IsConnected = false;
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ConnectionFailedException::typeid, this, "error_connectionFailed", "Could not register callback.");
-			return;
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ConnectionFailedException::typeid, Name, "error_connectionFailed", "Could not register callback.");
 		}
-		else
-		{
-			log->Debug("Callback registered successfully.");
-		}
+		log->Debug("Callback registered successfully.");
 		cam->start();
 
 		ActivateChannel(CHANNEL_NAME_AMPLITUDE);
@@ -145,8 +139,7 @@ void TIVoxel::ConnectImpl()
 	{
 		// this exception was unexpected, log it and throw our own one
 		log->Error(ex->Message);
-		ExceptionBuilder::Throw(MetriCam2::Exceptions::ConnectionFailedException::typeid, this, "error_connectionFailed", "Unexpected error: " + ex->Message);
-		return;
+		throw ExceptionBuilder::Build(MetriCam2::Exceptions::ConnectionFailedException::typeid, Name, "error_connectionFailed", "Unexpected error: " + ex->Message);
 	}
 	finally
 	{
@@ -231,8 +224,7 @@ Object^ TIVoxel::GetParameterByName(String^ name)
 
 		if (!boolParam->get(value, true))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "error_getParameter", "Could not convert value of parameter " + name + ".");
-			return false;
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "error_getParameter", "Could not convert value of parameter " + name + ".");
 		}
 
 		log->Debug(name + " = " + value.ToString());
@@ -253,8 +245,7 @@ Object^ TIVoxel::GetParameterByName(String^ name)
 		int value;
 		if (!intParam->get(value, true))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "error_getParameter", "Could not convert value of parameter " + name + ".");
-			return false;
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "error_getParameter", "Could not convert value of parameter " + name + ".");
 		}
 
 		String^ unit = msclr::interop::marshal_as<String^>(intParam->unit());
@@ -267,8 +258,7 @@ Object^ TIVoxel::GetParameterByName(String^ name)
 		uint value;
 		if (!uintParam->get(value, true))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "error_getParameter", "Could not convert value of parameter " + name + ".");
-			return false;
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "error_getParameter", "Could not convert value of parameter " + name + ".");
 		}
 
 		String^ unit = msclr::interop::marshal_as<String^>(uintParam->unit());
@@ -281,8 +271,7 @@ Object^ TIVoxel::GetParameterByName(String^ name)
 		float value;
 		if (!floatParam->get(value, true))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "error_getParameter", "Could not convert value of parameter " + name + ".");
-			return false;
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "error_getParameter", "Could not convert value of parameter " + name + ".");
 		}
 
 		String^ unit = msclr::interop::marshal_as<String^>(floatParam->unit());
@@ -295,8 +284,7 @@ Object^ TIVoxel::GetParameterByName(String^ name)
 		int value;
 		if (!enumParam->get(value, true))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "error_getParameter", "Could not convert value of parameter " + name + ".");
-			return false;
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "error_getParameter", "Could not convert value of parameter " + name + ".");
 		}
 		log->Debug(name + " = " + value.ToString());
 
@@ -313,8 +301,7 @@ Object^ TIVoxel::GetParameterByName(String^ name)
 	}
 	else
 	{
-		ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "error_getParameter", "Could not convert value of parameter " + name + ". Unsupported parameter type.");
-		return false;
+		throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "error_getParameter", "Could not convert value of parameter " + name + ". Unsupported parameter type.");
 	}
 }
 
@@ -343,7 +330,7 @@ void TIVoxel::SetParameterByName(String^ name, Object^ value)
 		bool val = (bool)value;
 		if (!boolParam->set(val))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "Could not set parameter " + name + " to " + val + ".");
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "Could not set parameter " + name + " to " + val + ".");
 		}
 		return;
 	}
@@ -352,7 +339,7 @@ void TIVoxel::SetParameterByName(String^ name, Object^ value)
 		int val = (int)value;
 		if (!intParam->set(val))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "Could not set parameter " + name + " to " + val + ".");
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "Could not set parameter " + name + " to " + val + ".");
 		}
 		return;
 	}
@@ -361,7 +348,7 @@ void TIVoxel::SetParameterByName(String^ name, Object^ value)
 		uint val = (uint)value;
 		if (!uintParam->set(val))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "Could not set parameter " + name + " to " + val + ".");
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "Could not set parameter " + name + " to " + val + ".");
 		}
 		return;
 	}
@@ -370,7 +357,7 @@ void TIVoxel::SetParameterByName(String^ name, Object^ value)
 		float val = (float)value;
 		if (!floatParam->set(val))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "Could not set parameter " + name + " to " + val + ".");
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "Could not set parameter " + name + " to " + val + ".");
 		}
 		return;
 	}
@@ -379,12 +366,12 @@ void TIVoxel::SetParameterByName(String^ name, Object^ value)
 		int val = (System::UInt32)value;
 		if (!enumParam->set(val))
 		{
-			ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "Could not set parameter " + name + " to " + val + ".");
+			throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "Could not set parameter " + name + " to " + val + ".");
 		}
 		return;
 	}
 
-	ExceptionBuilder::Throw(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, this, "error_setParameter", "Could not set parameter " + name + ". Parameter type is unsupported.");
+	throw ExceptionBuilder::Build(MetriCam2::Exceptions::ParameterNotSupportedException::typeid, Name, "error_setParameter", "Could not set parameter " + name + ". Parameter type is unsupported.");
 	return;
 }
 
@@ -938,7 +925,7 @@ void TIVoxel::SetIntegrationDutyCycle(uint val)
 
 	if (regOverflow)
 	{
-		ExceptionBuilder::Throw(InvalidOperationException::typeid, this, "error_setParameter", "Integration Duty Cycle beyond limit. Change it to a lower value.");
+		throw ExceptionBuilder::Build(InvalidOperationException::typeid, Name, "error_setParameter", "Integration Duty Cycle beyond limit. Change it to a lower value.");
 	}
 }
 
@@ -1125,7 +1112,7 @@ void TIVoxel::SetQuads(unsigned int val)
 {
 	if (val != 4 && val != 6)
 	{
-		ExceptionBuilder::Throw(InvalidOperationException::typeid, this, "error_setParameter", "Quads must be 4 or 6!");
+		throw ExceptionBuilder::Build(InvalidOperationException::typeid, Name, "error_setParameter", "Quads must be 4 or 6!");
 	}
 
 	System::Threading::Monitor::Enter(settingsLock);
@@ -1147,7 +1134,7 @@ void TIVoxel::SetSubFrames(uint val)
 {
 	if (val != 1 && val != 2 && val != 4)
 	{
-		ExceptionBuilder::Throw(InvalidOperationException::typeid, this, "error_setParameter", "Subframes must be 1, 2 or 4!");
+		throw ExceptionBuilder::Build(InvalidOperationException::typeid, Name, "error_setParameter", "Subframes must be 1, 2 or 4!");
 	}
 
 	System::Threading::Monitor::Enter(settingsLock);

--- a/BetaCameras/UEye/UEyeCamera.cs
+++ b/BetaCameras/UEye/UEyeCamera.cs
@@ -446,7 +446,7 @@ namespace MetriCam2.Cameras
                 deviceID = GetDeviceIDbySerial();
                 if (deviceID <= 0)
                 {
-                    ExceptionBuilder.Throw(typeof(MetriCam2.Exceptions.ConnectionFailedException), Name, "error_connectionFailed", String.Format("Could not connect to camera with the serial number {0}.", SerialNumber));
+                    throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", String.Format("Could not connect to camera with the serial number {0}.", SerialNumber));
                 }
                 deviceID |= uEyeDriverWrapper.IS_USE_DEVICE_ID;
             }
@@ -456,13 +456,13 @@ namespace MetriCam2.Cameras
             if (nRet == uEyeDriverWrapper.IS_STARTER_FW_UPLOAD_NEEDED)
             {
                 // TODO: Driver allows upload of new firmware. Check IDS docs for sample code.
-                ExceptionBuilder.Throw(typeof(MetriCam2.Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "This camera requires a new firmware. Please install with the appropriate tool from the camera vendor.");
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed", "This camera requires a new firmware. Please install with the appropriate tool from the camera vendor.");
 
             }
                 
             if (nRet != uEyeDriverWrapper.IS_SUCCESS)
             {
-                ExceptionBuilder.Throw(typeof(MetriCam2.Exceptions.ConnectionFailedException), Name, "error_connectionFailed");
+                throw ExceptionBuilder.Build(typeof(Exceptions.ConnectionFailedException), Name, "error_connectionFailed");
             }
             
 
@@ -651,8 +651,7 @@ namespace MetriCam2.Cameras
                 case ChannelNames.Intensity:
                     return CalcIntensity();
                 default:
-                    ExceptionBuilder.Throw(typeof(ArgumentException), this, "error_invalidChannelName", channelName);
-                    return null;
+                    throw ExceptionBuilder.Build(typeof(ArgumentException), Name, "error_invalidChannelName", channelName);
             }
         }
         #endregion

--- a/BetaCameras/ifm/O3D3xx.cs
+++ b/BetaCameras/ifm/O3D3xx.cs
@@ -488,7 +488,7 @@ namespace MetriCam2.Cameras
                 {
                     _edit.StopEditingApplication();
                     SetConfigurationMode(Mode.Run);
-                    ExceptionBuilder.Throw(typeof(ArgumentException), this, "error_invalidApplicationId", _applicationId.ToString());
+                    throw ExceptionBuilder.Build(typeof(ArgumentException), Name, "error_invalidApplicationId", _applicationId.ToString());
                 }
             }
 
@@ -665,8 +665,7 @@ namespace MetriCam2.Cameras
                         return CalcRawConfidanceImage();
                 }
             }
-            ExceptionBuilder.Throw(typeof(ArgumentException), this, "error_invalidChannelName", channelName);
-            return null;
+            throw ExceptionBuilder.Build(typeof(ArgumentException), Name, "error_invalidChannelName", channelName);
         }
         #endregion
         #endregion

--- a/MetriCam2/Camera.cs
+++ b/MetriCam2/Camera.cs
@@ -952,7 +952,9 @@ namespace MetriCam2
         /// </summary>
         /// <remarks>This flag is checked in <see cref="CalcChannel"/> to catch this common error in end user software.</remarks>
         private bool hasUpdateBeenCalled = false;
+#if !NETSTANDARD2_0
         private static string calibrationPathRegistry = null;
+#endif
         #endregion
 
         #region Public Properties
@@ -1070,7 +1072,7 @@ namespace MetriCam2
             {
                 if (IsConnected)
                 {
-                    ExceptionBuilder.Throw(typeof(InvalidOperationException), this, "error_changeParameterConnected", "Serial Number");
+                    throw ExceptionBuilder.Build(typeof(InvalidOperationException), Name, "error_changeParameterConnected", "Serial Number");
                 }
                 serialNumber = value;
             }
@@ -1207,7 +1209,7 @@ namespace MetriCam2
 
             if (this.IsConnected)
             {
-                ExceptionBuilder.Throw(typeof(InvalidOperationException), this, "error_connectionFailed");
+                throw ExceptionBuilder.Build(typeof(InvalidOperationException), Name, "error_connectionFailed");
             }
 
             this.FrameNumber = -1;
@@ -1309,7 +1311,7 @@ namespace MetriCam2
         {
             if (!IsConnected)
             {
-                ExceptionBuilder.Throw(typeof(InvalidOperationException), this, "error_cameraNotConnected");
+                throw ExceptionBuilder.Build(typeof(InvalidOperationException), Name, "error_cameraNotConnected");
             }
 
             lock (cameraLock)
@@ -1389,8 +1391,7 @@ namespace MetriCam2
         {
             if (!IsConnected)
             {
-                ExceptionBuilder.Throw(typeof(InvalidOperationException), this, "error_cameraNotConnected");
-                return null;
+                throw ExceptionBuilder.Build(typeof(InvalidOperationException), Name, "error_cameraNotConnected");
             }
 
             if (intrinsicsCache.ContainsKey(channelName) && intrinsicsCache[channelName] != null)
@@ -1430,8 +1431,7 @@ namespace MetriCam2
         {
             if (!IsConnected)
             {
-                ExceptionBuilder.Throw(typeof(InvalidOperationException), this, "error_cameraNotConnected");
-                return null;
+                throw ExceptionBuilder.Build(typeof(InvalidOperationException), Name, "error_cameraNotConnected");
             }
 
             if (channelFromName == channelToName)
@@ -1557,8 +1557,7 @@ namespace MetriCam2
 
             if (!hasUpdateBeenCalled)
             {
-                ExceptionBuilder.Throw(typeof(InvalidOperationException), this, "error_updateMustBeCalledBeforeCalcChannel");
-                return null;
+                throw ExceptionBuilder.Build(typeof(InvalidOperationException), Name, "error_updateMustBeCalledBeforeCalcChannel");
             }
             CameraImage img;
             if (enableImplicitThreadSafety)
@@ -1578,8 +1577,7 @@ namespace MetriCam2
             {
                 if (!IsChannelActive(channelName))
                 {
-                    ExceptionBuilder.Throw(typeof(ArgumentException), this, "error_inactiveChannelName", channelName);
-                    return null;
+                    throw ExceptionBuilder.Build(typeof(ArgumentException), Name, "error_inactiveChannelName", channelName);
                 }
 
                 img = CalcChannelImpl(channelName);
@@ -2446,9 +2444,10 @@ namespace MetriCam2
             }
 
 #if DEBUG
-            ExceptionBuilder.Throw(typeof(ArgumentException), this, "error_invalidChannelName", channelName);
-#endif
+            throw ExceptionBuilder.Build(typeof(ArgumentException), Name, "error_invalidChannelName", channelName);
+#else
             return null;
+#endif
         }
 
         /// <summary>
@@ -2466,9 +2465,9 @@ namespace MetriCam2
             ActiveChannels.Add(GetChannelDescriptor(channelName));
             return true;
         }
-        #endregion
+#endregion
 
-        #region Abstract and Empty Virtual Methods
+#region Abstract and Empty Virtual Methods
         /// <summary>
         /// Reset list of available channels (<see cref="Channels"/>) to union of all cameras supported by the implementing class.
         /// </summary>
@@ -2526,9 +2525,9 @@ namespace MetriCam2
         /// If your implementation needs locking, use <see cref="Camera.cameraLock"/>.
         /// </remarks>
         protected abstract CameraImage CalcChannelImpl(string channelName);
-        #endregion
+#endregion
 
-        #region Private Methods
+#region Private Methods
         /// <summary>
         /// Finds the best matching Projective Transform for a channel of this camera.
         /// </summary>
@@ -2847,6 +2846,6 @@ namespace MetriCam2
             }
             return entryAssembly;
         }
-        #endregion
+#endregion
     }
 }

--- a/MetriCam2/Exceptions/ExceptionBuilder.cs
+++ b/MetriCam2/Exceptions/ExceptionBuilder.cs
@@ -33,31 +33,18 @@ namespace MetriCam2
             // Fall-back
             return new Exception(exType + ": " + msg);
         }
+        #endregion
 
-        private static void Throw(Type exType, string msg)
+        #region Public Methods
+        public static MetriCam2Exception Build(Type exType, string cameraName, string message, Exception inner)
         {
-            throw Build(exType, msg);
-        }
-
-        private static MetriCam2Exception Build(Type exType, string msg, Exception inner)
-        {
+            string msg = cameraName + ": " + message;
             ConstructorInfo ci = exType.GetConstructor(new Type[] { typeof(string), typeof(Exception) });
             log.ErrorFormat("{0}: {1}", exType.Name, msg);
             log.ErrorFormat("    inner exception {0}: {1}", inner.GetType().Name, inner.Message);
             return (MetriCam2Exception)ci.Invoke(new object[] { msg, inner });
         }
-        private static void Throw(Type exType, string msg, Exception inner)
-        {
-            throw Build(exType, msg, inner);
-        }
 
-        private static void Throw(Type exType, string name, string message, Exception inner)
-        {
-            throw Build(exType, name + ": " + message, inner);
-        }
-        #endregion
-
-        #region Public Methods
         /// <summary>
         /// This is a special version of the Build methods to allow customer-specific exception IDs.
         /// </summary>
@@ -96,11 +83,8 @@ namespace MetriCam2
                 return new MetriCam2Exception(fullMessage, ex);
             }
         }
-        public static Exception Build(Type exType, Camera cam, string messageCode)
-        {
-            return Build(exType, cam.Name, messageCode);
-        }
-        public static Exception Build(Type exType, string name, string messageCode)
+
+        public static Exception Build(Type exType, string cameraName, string messageCode)
         {
             string localizedErrorMessage = Localization.GetString(messageCode);
 
@@ -108,7 +92,7 @@ namespace MetriCam2
             {
                 localizedErrorMessage = messageCode;
             }
-            string msg = name + ": " + localizedErrorMessage;
+            string msg = cameraName + ": " + localizedErrorMessage;
 
             return Build(exType, msg);
         }
@@ -117,111 +101,26 @@ namespace MetriCam2
         /// Throw methods are deprecated. Use <code>throw Build(...)</code> instead.
         /// </summary>
         /// <param name="exType"></param>
-        /// <param name="cam"></param>
-        /// <param name="messageCode"></param>
-        public static void Throw(Type exType, Camera cam, string messageCode)
-        {
-            throw Build(exType, cam.Name, messageCode);
-        }
-
-        /// <summary>
-        /// Throw methods are deprecated. Use <code>throw Build(...)</code> instead.
-        /// </summary>
-        /// <param name="exType"></param>
-        /// <param name="name"></param>
-        /// <param name="messageCode"></param>
-        public static void Throw(Type exType, string name, string messageCode)
-        {
-            throw Build(exType, name, messageCode);
-        }
-
-        /// <summary>
-        /// Throw methods are deprecated. Use <code>throw Build(...)</code> instead.
-        /// </summary>
-        /// <param name="exType"></param>
-        /// <param name="cam"></param>
+        /// <param name="cameraName"></param>
         /// <param name="messageCode"></param>
         /// <param name="messageExtraInfo"></param>
-        public static void Throw(Type exType, Camera cam, string messageCode, string messageExtraInfo)
-        {
-            Throw(exType, cam.Name, messageCode, messageExtraInfo);
-        }
-
-        /// <summary>
-        /// Throw methods are deprecated. Use <code>throw Build(...)</code> instead.
-        /// </summary>
-        /// <param name="exType"></param>
-        /// <param name="name"></param>
-        /// <param name="messageCode"></param>
-        /// <param name="messageExtraInfo"></param>
-        public static void Throw(Type exType, string name, string messageCode, string messageExtraInfo)
+        public static Exception Build(Type exType, string cameraName, string messageCode, string messageExtraInfo)
         {
             string localizedErrorMessage = Localization.GetString(messageCode);
 
             if (localizedErrorMessage == null)
             {
-                Throw(exType, name, "Unknown error occurred.");
+                return Build(exType, cameraName, "Unknown error occurred.");
             }
 
             if (localizedErrorMessage.Contains("{0}"))
             {
-                throw Build(exType, name + ": " + string.Format(localizedErrorMessage, messageExtraInfo));
+                return Build(exType, cameraName + ": " + string.Format(localizedErrorMessage, messageExtraInfo));
             }
             else
             {
-                throw Build(exType, name + ": " + localizedErrorMessage + "\n" + messageExtraInfo);
+                return Build(exType, cameraName + ": " + localizedErrorMessage + "\n" + messageExtraInfo);
             }
-        }
-
-        /// <summary>
-        /// Throw methods are deprecated. Use <code>throw Build(...)</code> instead.
-        /// </summary>
-        /// <param name="exType"></param>
-        /// <param name="cam"></param>
-        /// <param name="messageCode"></param>
-        /// <param name="messageExtraInfo"></param>
-        /// <param name="oniIError"></param>
-        public static void Throw(Type exType, Camera cam, string messageCode, string messageExtraInfo, string oniIError)
-        {
-            Throw(exType, cam.Name, messageCode, messageExtraInfo, oniIError);
-        }
-
-        /// <summary>
-        /// Throw methods are deprecated. Use <code>throw Build(...)</code> instead.
-        /// </summary>
-        /// <param name="exType"></param>
-        /// <param name="name"></param>
-        /// <param name="messageCode"></param>
-        /// <param name="messageExtraInfo"></param>
-        /// <param name="oniIError"></param>
-        public static void Throw(Type exType, string name, string messageCode, string messageExtraInfo, string oniIError)
-        {
-            string localizedErrorMessage = Localization.GetString(messageCode);
-
-            if (localizedErrorMessage == null)
-            {
-                Throw(exType, name, "Unknown error occurred.");
-            }
-
-            if (localizedErrorMessage.Contains("{0}"))
-            {
-                Throw(exType, name + ": " + String.Format(localizedErrorMessage, messageExtraInfo) + "\nOpenNI2 error message: " + oniIError);
-            }
-            else
-            {
-                Throw(exType, name + ": " + localizedErrorMessage + "\n" + messageExtraInfo + "\nOpenNI2 error message: " + oniIError);
-            }
-        }
-
-        /// <summary>
-        /// Throw methods are deprecated. Use <code>throw Build(...)</code> instead.
-        /// </summary>
-        /// <param name="exType"></param>
-        /// <param name="cam"></param>
-        /// <param name="inner"></param>
-        public static void Throw(Type exType, Camera cam, Exception inner)
-        {
-            Throw(exType, cam.Name, inner.Message, inner);
         }
         #endregion
     }

--- a/Tests/UnitTestParameterMechanism/Program.cs
+++ b/Tests/UnitTestParameterMechanism/Program.cs
@@ -8,9 +8,6 @@ using Metrilus.Logging;
 using Metrilus.Util;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Metrilus.Logging;
 
 namespace MetriCam2.Tests.UnitTestParameterMechanism
 {


### PR DESCRIPTION
I removed the obsolete `Throw` methods and replaced them with `throw Build`. The `Throw` methods were a bad idea in the first place for two reasons:

1. They obstruct the original location where the exception happened and compromised the stack trace.
2. They obfuscated the control flow. The compiler / intellisense could not recognize that an exception would be thrown and many places had to have an additional `return null` or similar.