### PR TITLE
Orbbec improvements

### DIFF
--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -184,6 +184,12 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 		log->Warn(msg);
 		throw gcnew MetriCam2::Exceptions::ConnectionFailedException(msg);
 	}
+	// Read serial number
+	char serialNumber[12];
+	int data_size = sizeof(serialNumber);
+	Device.getProperty((int)ONI_DEVICE_PROPERTY_SERIAL_NUMBER, (void *)serialNumber, &data_size);
+	SerialNumber = gcnew String(serialNumber);
+
 	VendorID = _pCamData->openNICam->m_vid;
 	ProductID = _pCamData->openNICam->m_pid;
 	_pCamData->openNICam->ldp_set(true); //Ensure eye-safety by turning on the proximity sensor

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -675,7 +675,7 @@ FloatCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcZImage()
 	}
 
 	const openni::DepthPixel* pDepthRow = (const openni::DepthPixel*)depthFrame.getData();
-	int rowSize = depthFrame.getStrideInBytes() / sizeof(openni::DepthPixel);
+	const int rowSize = depthFrame.getStrideInBytes() / sizeof(openni::DepthPixel);
 	FloatCameraImage^ depthDataMeters = gcnew FloatCameraImage(depthFrame.getWidth(), depthFrame.getHeight());
 	depthDataMeters->ChannelName = ChannelNames::ZImage;
 
@@ -708,9 +708,7 @@ ColorCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcColor()
 	}
 
 	Bitmap^ bitmap = gcnew Bitmap(_pCamData->colorWidth, _pCamData->colorHeight, System::Drawing::Imaging::PixelFormat::Format24bppRgb);
-
 	System::Drawing::Rectangle^ imageRect = gcnew System::Drawing::Rectangle(0, 0, _pCamData->colorWidth, _pCamData->colorHeight);
-
 	System::Drawing::Imaging::BitmapData^ bmpData = bitmap->LockBits(*imageRect, System::Drawing::Imaging::ImageLockMode::WriteOnly, bitmap->PixelFormat);
 
 	const unsigned char* source = (unsigned char*)colorFrame.getData();
@@ -751,7 +749,7 @@ Point3fCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcPoint3fImage()
 	}
 
 	const openni::DepthPixel* pDepthRow = (const openni::DepthPixel*)depthFrame.getData();
-	int rowSize = depthFrame.getStrideInBytes() / sizeof(openni::DepthPixel);
+	const int rowSize = depthFrame.getStrideInBytes() / sizeof(openni::DepthPixel);
 	Point3fCameraImage^ pointsImage = gcnew Point3fCameraImage(depthFrame.getWidth(), depthFrame.getHeight());
 	pointsImage->ChannelName = ChannelNames::Point3DImage;
 
@@ -789,13 +787,13 @@ FloatCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcIRImage()
 	}
 
 	const openni::Grayscale16Pixel* pIRRow = (const openni::Grayscale16Pixel*)irFrame.getData();
-	int rowSize = irFrame.getStrideInBytes() / sizeof(openni::Grayscale16Pixel);
+	const int rowSize = irFrame.getStrideInBytes() / sizeof(openni::Grayscale16Pixel);
 	FloatCameraImage^ irData = gcnew FloatCameraImage(irFrame.getWidth(), irFrame.getHeight(), 0.0f);
 	irData->ChannelName = ChannelNames::Intensity;
 
-	// Compensate for offset bug: Translate infrared frame by 8 pixels in vertical direction to match infrared with depth image.
-	// Leave first 8 rows black. Constructor of FloatCameraImage assigns zero to every pixel as initial value by default.
-	int yTranslation = 8;
+	// Compensate for offset bug: Translate infrared frame by 16 pixels in vertical direction to match infrared with depth image.
+	// Leave first 16 rows black. Constructor of FloatCameraImage assigns zero to every pixel as initial value by default.
+	const int yTranslation = 16;
 
 	for (int y = 0; y < irFrame.getHeight() - yTranslation; ++y)
 	{

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -17,7 +17,7 @@ MetriCam2::Cameras::AstraOpenNI::AstraOpenNI()
 	if (!initSucceeded)
 	{
 		log->Error("Could not initialize OpenNI");
-		throw gcnew System::ApplicationException("Could not initialize OpenNI" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError());
+		throw gcnew System::ApplicationException("Could not initialize OpenNI" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError()));
 	}
 
 	// Init to most reasonable values; update during ConnectImpl

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -126,7 +126,7 @@ System::Collections::Generic::Dictionary<String^, String^>^ MetriCam2::Cameras::
 
 	if (devicesCount >= MAX_DEVICES)
 	{
-		log->Error("The number of supported devices is limited.");
+		log->ErrorFormat("The number of devices ({0}) exceeds the number supported by MetriCam 2 ({1}).", devicesCount, MAX_DEVICES);
 		OpenNIShutdown();
 		return nullptr;
 	}
@@ -141,14 +141,14 @@ System::Collections::Generic::Dictionary<String^, String^>^ MetriCam2::Cameras::
 		rc = device->open(deviceUris[i]);
 		if (openni::Status::STATUS_OK != rc) {
 			// CheckOpenNIError(rc, "Couldn't open device : ", deviceUris[i]);
-			System::Diagnostics::Debug::WriteLine("GetSerialNumberOfAttachedCameras: cannot open device");
+			log->WarnFormat("GetSerialNumberOfAttachedCameras: Couldn't open device {0}", gcnew String(deviceUris[i]));
 			continue;
 		}
 
 		rc = depthStreams[i].create(*device, openni::SENSOR_DEPTH);
 		if (openni::Status::STATUS_OK != rc) {
 			// CheckOpenNIError(rc, "Couldn't create stream on device : ", deviceUris[i]);
-			System::Diagnostics::Debug::WriteLine("GetSerialNumberOfAttachedCameras: cannot create device");
+			log->WarnFormat("GetSerialNumberOfAttachedCameras: Couldn't create depth stream on device {0}", gcnew String(deviceUris[i]));
 			continue;
 		}
 
@@ -159,15 +159,14 @@ System::Collections::Generic::Dictionary<String^, String^>^ MetriCam2::Cameras::
 		rc = depthStreams[i].start();
 		if (openni::Status::STATUS_OK != rc) {
 			// CheckOpenNIError(rc, "Couldn't create stream on device : ", serialNumbers[i]);
-			System::Diagnostics::Debug::WriteLine("GetSerialNumberOfAttachedCameras: cannot start depth stream");
+			log->WarnFormat("GetSerialNumberOfAttachedCameras: Couldn't start depth stream on device {0}", gcnew String(serialNumbers[i]));
 			continue;
 		}
 
 		if (!depthStreams[i].isValid())
 		{
 			// printf("SimpleViewer: No valid streams. Exiting\n");
-			System::Diagnostics::Debug::WriteLine("GetSerialNumberOfAttachedCameras: depth stream not valid");
-			openni::OpenNI::shutdown();
+			log->WarnFormat("GetSerialNumberOfAttachedCameras: No valid depth stream");
 			continue;
 		}
 
@@ -222,7 +221,7 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 	int rc = _pCamData->openNICam->init(deviceURI);
 	if (rc != openni::Status::STATUS_OK)
 	{
-		auto msg = String::Format("Could not init connection to device {0}.", SerialNumber);
+		auto msg = String::Format("{0}: Could not init connection to device {1}.", Name, SerialNumber);
 		log->Warn(msg);
 		throw gcnew MetriCam2::Exceptions::ConnectionFailedException(msg);
 	}

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -192,7 +192,7 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 
 	VendorID = _pCamData->openNICam->m_vid;
 	ProductID = _pCamData->openNICam->m_pid;
-	_pCamData->openNICam->ldp_set(true); //Ensure eye-safety by turning on the proximity sensor
+	//_pCamData->openNICam->ldp_set(true); //Ensure eye-safety by turning on the proximity sensor
 
 	// Start depth stream
 	Device.setImageRegistrationMode(openni::IMAGE_REGISTRATION_OFF);
@@ -217,8 +217,8 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 	// Turn Emitter on if any depth channel is active.
 	// (querying from device here would return wrong value)
 	// (do not use properties as they check against their current value which might be wrong)
-	_emitterEnabled = (IsChannelActive(ChannelNames::ZImage) || IsChannelActive(ChannelNames::Point3DImage));
-	SetEmitterStatus(_emitterEnabled);
+	//_emitterEnabled = (IsChannelActive(ChannelNames::ZImage) || IsChannelActive(ChannelNames::Point3DImage));
+	//SetEmitterStatus(_emitterEnabled);
 	_irFlooderEnabled = false; // Default to IR flooder off.
 	SetIRFlooderStatus(_irFlooderEnabled);
 }

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -17,6 +17,7 @@ MetriCam2::Cameras::AstraOpenNI::AstraOpenNI()
 	if (!initSucceeded)
 	{
 		log->Error("Could not initialize OpenNI");
+		throw gcnew System::ApplicationException("Could not initialize OpenNI" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError());
 	}
 
 	// Init to most reasonable values; update during ConnectImpl
@@ -56,7 +57,7 @@ MetriCam2::Cameras::AstraOpenNI::!AstraOpenNI() {
 
 void MetriCam2::Cameras::AstraOpenNI::LogOpenNIError(String^ status) 
 {
-	log->Error(status + "\n" + gcnew String(openni::OpenNI::getExtendedError()));
+	log->Error(status + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError()));
 }
 
 bool MetriCam2::Cameras::AstraOpenNI::OpenNIInit() 
@@ -418,8 +419,6 @@ void MetriCam2::Cameras::AstraOpenNI::DisconnectImpl()
 
 void MetriCam2::Cameras::AstraOpenNI::UpdateImpl()
 {
-	//printf("O/%s: UpdateImpl\n", SerialNumber);
-
 	const int NumRequestedStreams = 3;
 	openni::VideoStream** ppStreams = new openni::VideoStream*[NumRequestedStreams];
 	for (size_t i = 0; i < NumRequestedStreams; i++)
@@ -431,17 +430,14 @@ void MetriCam2::Cameras::AstraOpenNI::UpdateImpl()
 	if (IsChannelActive(ChannelNames::ZImage) || IsChannelActive(ChannelNames::Point3DImage))
 	{
 		ppStreams[DepthIdx] = &DepthStream;
-		//printf("%s: Added depth at %d\n", SerialNumber, DepthIdx);
 	}
 	if (IsChannelActive(ChannelNames::Intensity))
 	{
 		ppStreams[IrIdx] = &IrStream;
-		//printf("%s: Added IR at %d\n", SerialNumber, IrIdx);
 	}
 	if (IsChannelActive(ChannelNames::Color))
 	{
 		ppStreams[ColorIdx] = &ColorStream;
-		//printf("%s: Added color at %d\n", SerialNumber, ColorIdx);
 	}
 
 	int iter = 0;
@@ -450,16 +446,15 @@ void MetriCam2::Cameras::AstraOpenNI::UpdateImpl()
 	{
 		int changedIndex;
 		openni::Status rc = openni::OpenNI::waitForAnyStream(ppStreams, NumRequestedStreams, &changedIndex, 5000);
-		//printf("%s: Iteration %d: rc = %d, changed = %d\n", SerialNumber, iter++, rc, changedIndex);
 		if (openni::STATUS_OK != rc)
 		{
 			if (openni::STATUS_TIME_OUT == rc)
 			{
-				log->Error(String::Format("{0} {1}: Wait failed: timeout\n", Name, SerialNumber));
+				log->ErrorFormat("{0} {1}: Wait failed: timeout", Name, SerialNumber);
 			}
 			else
 			{
-				log->Error(String::Format("{0} {1}: Wait failed: rc={2}\n", Name, SerialNumber, (int)rc));
+				log->ErrorFormat("{0} {1}: Wait failed: rc={2}", Name, SerialNumber, (int)rc);
 			}
 			return;
 		}
@@ -505,7 +500,7 @@ void MetriCam2::Cameras::AstraOpenNI::InitDepthStream()
 	DepthStream.setMirroringEnabled(false);
 	if (openni::STATUS_OK != rc)
 	{
-		String^ msg = "Couldn't create depth stream:\n" + gcnew String(openni::OpenNI::getExtendedError());
+		String^ msg = "Couldn't create depth stream:" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError());
 		log->Error(msg);
 		throw gcnew Exception(msg);
 	}
@@ -518,7 +513,7 @@ void MetriCam2::Cameras::AstraOpenNI::InitIRStream()
 	IrStream.setMirroringEnabled(false);
 	if (openni::STATUS_OK != rc)
 	{
-		log->Error("Couldn't create IR stream:\n" + gcnew String(openni::OpenNI::getExtendedError()));
+		log->Error("Couldn't create IR stream:" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError()));
 		return;
 	}
 }
@@ -530,7 +525,7 @@ void MetriCam2::Cameras::AstraOpenNI::InitColorStream()
 	ColorStream.setMirroringEnabled(false);
 	if (openni::STATUS_OK != rc)
 	{
-		log->Error("Couldn't create color stream:\n" + gcnew String(openni::OpenNI::getExtendedError()));
+		log->Error("Couldn't create color stream:" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError()));
 		return;
 	}
 }
@@ -558,14 +553,14 @@ void MetriCam2::Cameras::AstraOpenNI::ActivateChannelImpl(String^ channelName)
 		rc = DepthStream.start();
 		if (openni::STATUS_OK != rc)
 		{
-			log->Error("Couldn't start depth stream:\n" + gcnew String(openni::OpenNI::getExtendedError()));
+			log->Error("Couldn't start depth stream:" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError()));
 			DepthStream.destroy();
 			return;
 		}
 
 		if (!DepthStream.isValid())
 		{
-			log->Error("No valid depth stream. Exiting\n");
+			log->Error("No valid depth stream. Exiting.");
 			return;
 		}
 
@@ -598,14 +593,14 @@ void MetriCam2::Cameras::AstraOpenNI::ActivateChannelImpl(String^ channelName)
 		rc = IrStream.start();
 		if (openni::STATUS_OK != rc)
 		{
-			log->Error("Couldn't start IR stream:\n" + gcnew String(openni::OpenNI::getExtendedError()));
+			log->Error("Couldn't start IR stream:" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError()));
 			IrStream.destroy();
 			return;
 		}
 
 		if (!IrStream.isValid())
 		{
-			log->Error("No valid IR stream. Exiting\n");
+			log->Error("No valid IR stream. Exiting.");
 			return;
 		}
 
@@ -630,14 +625,14 @@ void MetriCam2::Cameras::AstraOpenNI::ActivateChannelImpl(String^ channelName)
 		rc = ColorStream.start();
 		if (openni::STATUS_OK != rc)
 		{
-			log->Error("Couldn't start color stream:\n" + gcnew String(openni::OpenNI::getExtendedError()));
+			log->Error("Couldn't start color stream:" + Environment::NewLine + gcnew String(openni::OpenNI::getExtendedError()));
 			ColorStream.destroy();
 			return;
 		}
 
 		if (!ColorStream.isValid())
 		{
-			log->Error("No valid color stream. Exiting\n");
+			log->Error("No valid color stream. Exiting.");
 			return;
 		}
 
@@ -676,7 +671,7 @@ FloatCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcZImage()
 
 	if (!depthFrame.isValid())
 	{
-		log->Error("Depth frame is not valid...\n");
+		log->Error("Depth frame is not valid...");
 		return nullptr;
 	}
 
@@ -709,7 +704,7 @@ ColorCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcColor()
 
 	if (!colorFrame.isValid())
 	{
-		log->Error("Color frame is not valid...\n");
+		log->Error("Color frame is not valid...");
 		return nullptr;
 	}
 
@@ -750,7 +745,7 @@ Point3fCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcPoint3fImage()
 
 	if (!depthFrame.isValid())
 	{
-		log->Error("Depth frame is not valid...\n");
+		log->Error("Depth frame is not valid...");
 		return nullptr;
 	}
 
@@ -788,7 +783,7 @@ FloatCameraImage ^ MetriCam2::Cameras::AstraOpenNI::CalcIRImage()
 
 	if (!irFrame.isValid())
 	{
-		log->Error("IR frame is not valid...\n");
+		log->Error("IR frame is not valid...");
 		return nullptr;
 	}
 

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -114,12 +114,9 @@ System::Collections::Generic::Dictionary<String^, String^>^ MetriCam2::Cameras::
 	}
 
 	openni::Status rc = openni::STATUS_OK;
+	const char* deviceUris[MAX_DEVICES];
+	char serialNumbers[MAX_DEVICES][12]; // Astra serial number has 12 numbers
 
-	openni::VideoStream    depthStreams[MAX_DEVICES];
-	const char*            deviceUris[MAX_DEVICES];
-	char                   serialNumbers[MAX_DEVICES][12]; // Astra serial number has 12 numbers
-
-														   // Enumerate devices
 	openni::Array<openni::DeviceInfo> deviceList;
 	openni::OpenNI::enumerateDevices(&deviceList);
 	int devicesCount = deviceList.getSize();
@@ -145,34 +142,11 @@ System::Collections::Generic::Dictionary<String^, String^>^ MetriCam2::Cameras::
 			continue;
 		}
 
-		rc = depthStreams[i].create(*device, openni::SENSOR_DEPTH);
-		if (openni::Status::STATUS_OK != rc) {
-			// CheckOpenNIError(rc, "Couldn't create stream on device : ", deviceUris[i]);
-			log->WarnFormat("GetSerialNumberOfAttachedCameras: Couldn't create depth stream on device {0}", gcnew String(deviceUris[i]));
-			continue;
-		}
-
 		// Read serial number
 		int data_size = sizeof(serialNumbers[i]);
 		device->getProperty((int)ONI_DEVICE_PROPERTY_SERIAL_NUMBER, (void *)serialNumbers[i], &data_size);
 
-		rc = depthStreams[i].start();
-		if (openni::Status::STATUS_OK != rc) {
-			// CheckOpenNIError(rc, "Couldn't create stream on device : ", serialNumbers[i]);
-			log->WarnFormat("GetSerialNumberOfAttachedCameras: Couldn't start depth stream on device {0}", gcnew String(serialNumbers[i]));
-			continue;
-		}
-
-		if (!depthStreams[i].isValid())
-		{
-			// printf("SimpleViewer: No valid streams. Exiting\n");
-			log->WarnFormat("GetSerialNumberOfAttachedCameras: No valid depth stream");
-			continue;
-		}
-
-		// Close depth stream and device
-		depthStreams[i].stop();
-		depthStreams[i].destroy();
+		// Close device
 		device->close();
 		delete device;
 

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -25,20 +25,32 @@ namespace MetriCam2
 {
 	namespace Cameras 
 	{
-
 		struct OrbbecNativeCameraData
 		{
+			OrbbecNativeCameraData()
+			{
+				openNICam = new cmd();
+			}
+			~OrbbecNativeCameraData()
+			{
+				if (openNICam != nullptr)
+				{
+					delete openNICam;
+				}
+				openNICam = nullptr;
+			}
+
 			cmd* openNICam;
 
-			openni::VideoStream* depth;
+			openni::VideoStream depth;
 			int depthWidth;
 			int depthHeight;
 
-			openni::VideoStream* ir;
+			openni::VideoStream ir;
 			int irWidth;
 			int irHeight;
 
-			openni::VideoStream* color;
+			openni::VideoStream color;
 			int colorWidth;
 			int colorHeight;
 		};
@@ -179,6 +191,35 @@ namespace MetriCam2
 			virtual void DeactivateChannelImpl(String^ channelName) override;
 			
 		private:
+			property openni::Device& Device
+			{
+				openni::Device& get(void)
+				{
+					return _pCamData->openNICam->device;
+				}
+			}
+			property openni::VideoStream& DepthStream
+			{
+				openni::VideoStream& get(void)
+				{
+					return _pCamData->depth;
+				}
+			}
+			property openni::VideoStream& IrStream
+			{
+				openni::VideoStream& get(void)
+				{
+					return _pCamData->ir;
+				}
+			}
+			property openni::VideoStream& ColorStream
+			{
+				openni::VideoStream& get(void)
+				{
+					return _pCamData->color;
+				}
+			}
+
 			property ParamDesc<bool>^ EmitterEnabledDesc
 			{
 				inline ParamDesc<bool> ^get()

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -62,12 +62,29 @@ namespace MetriCam2
 			~AstraOpenNI();
 			!AstraOpenNI();
 
-			property int ProductID;
-			property int VendorID;
+			virtual property String^ Vendor
+			{
+				String^ get() override
+				{
+					return "Orbbec";
+				}
+			}
+			property int ProductID
+			{
+				int get() { return _pid; }
+			private:
+				void set(int value) { _pid = value; }
+			}
+			property int VendorID
+			{
+				int get() { return _vid; }
+			private:
+				void set(int value) { _vid = value; }
+			}
 
 			property bool EmitterEnabled
 			{
-				bool get(void)
+				bool get()
 				{
 					// Reading the emitter status via the "cmd" class does not yet work. Check in future version of experimental SDK.
 					return _emitterEnabled;
@@ -82,7 +99,7 @@ namespace MetriCam2
 
 			property bool IRFlooderEnabled
 			{
-				bool get(void)
+				bool get()
 				{
 					// Reading the IrFlood status via the "cmd" class does not yet work. Check in future version of experimental SDK.
 					return _irFlooderEnabled;
@@ -97,7 +114,7 @@ namespace MetriCam2
 
 			property int IRGain
 			{
-				int get(void)
+				int get()
 				{
 					return _irGain;
 				}
@@ -114,7 +131,7 @@ namespace MetriCam2
 			// Implementation in experimental interface seems to be buggy, changing the value destroys the distance image
 			property unsigned int IRExposure
 			{
-				unsigned int get(void)
+				unsigned int get()
 				{
 					//ir_exposure_get in cmd class not yet functional and can destroy the current state of the camera
 					throw gcnew NotImplementedException();
@@ -193,28 +210,28 @@ namespace MetriCam2
 		private:
 			property openni::Device& Device
 			{
-				openni::Device& get(void)
+				openni::Device& get()
 				{
 					return _pCamData->openNICam->device;
 				}
 			}
 			property openni::VideoStream& DepthStream
 			{
-				openni::VideoStream& get(void)
+				openni::VideoStream& get()
 				{
 					return _pCamData->depth;
 				}
 			}
 			property openni::VideoStream& IrStream
 			{
-				openni::VideoStream& get(void)
+				openni::VideoStream& get()
 				{
 					return _pCamData->ir;
 				}
 			}
 			property openni::VideoStream& ColorStream
 			{
-				openni::VideoStream& get(void)
+				openni::VideoStream& get()
 				{
 					return _pCamData->color;
 				}
@@ -222,9 +239,9 @@ namespace MetriCam2
 
 			property ParamDesc<bool>^ EmitterEnabledDesc
 			{
-				inline ParamDesc<bool> ^get()
+				inline ParamDesc<bool>^ get()
 				{
-					ParamDesc<bool> ^res = gcnew ParamDesc<bool>();
+					ParamDesc<bool>^ res = gcnew ParamDesc<bool>();
 					res->Unit = "";
 					res->Description = "Emitter is enabled";
 					res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
@@ -235,9 +252,9 @@ namespace MetriCam2
 
 			property ParamDesc<bool>^ IRFlooderEnabledDesc
 			{
-				inline ParamDesc<bool> ^get()
+				inline ParamDesc<bool>^ get()
 				{
-					ParamDesc<bool> ^res = gcnew ParamDesc<bool>();
+					ParamDesc<bool>^ res = gcnew ParamDesc<bool>();
 					res->Unit = "";
 					res->Description = "IR flooder is enabled";
 					res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
@@ -249,9 +266,9 @@ namespace MetriCam2
 			// Disabled while the IRExposure getter is not implemented
 			//property ParamDesc<unsigned int>^ IRExposureDesc
 			//{
-			//	inline ParamDesc<unsigned int> ^get()
+			//	inline ParamDesc<unsigned int>^ get()
 			//	{
-			//		ParamDesc<unsigned int> ^res = gcnew ParamDesc<unsigned int>();
+			//		ParamDesc<unsigned int>^ res = gcnew ParamDesc<unsigned int>();
 			//		res->Unit = "";
 			//		res->Description = "IR exposure";
 			//		res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
@@ -262,9 +279,9 @@ namespace MetriCam2
 
 			property ParamDesc<int>^ IRGainDesc
 			{
-				inline ParamDesc<int> ^get()
+				inline ParamDesc<int>^ get()
 				{
-					ParamDesc<int> ^res = ParamDesc::BuildRangeParamDesc(IR_Gain_MIN, IR_Gain_MAX);
+					ParamDesc<int>^ res = ParamDesc::BuildRangeParamDesc(IR_Gain_MIN, IR_Gain_MAX);
 					res->Unit = "";
 					res->Description = "IR gain";
 					res->ReadableWhen = ParamDesc::ConnectionStates::Connected;
@@ -305,6 +322,8 @@ namespace MetriCam2
 			bool _emitterEnabled;
 			bool _irFlooderEnabled;
 			OrbbecNativeCameraData* _pCamData;
+			int _vid;
+			int _pid;
 
 			msclr::interop::marshal_context marshalContext;
 		};

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -43,11 +43,12 @@ namespace MetriCam2
 			int colorHeight;
 		};
 
-		public ref class AstraOpenNI : Camera
+		public ref class AstraOpenNI : Camera, IDisposable
 		{
 		public:
 			AstraOpenNI();
 			~AstraOpenNI();
+			!AstraOpenNI();
 
 			property int ProductID;
 			property int VendorID;
@@ -241,6 +242,7 @@ namespace MetriCam2
 			static void LogOpenNIError(String^ status);
 			static int _openNIInitCounter = 0;
 
+			bool _isDisposed = false;
 			int _irGain = 0;
 
 			void InitDepthStream();

--- a/Samples/MinimalSample/MinimalSample.csproj
+++ b/Samples/MinimalSample/MinimalSample.csproj
@@ -10,9 +10,24 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MetriCam2.Samples.MinimalSample</RootNamespace>
     <AssemblyName>MinimalSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -64,11 +79,11 @@
     </Reference>
     <Reference Include="MetriPrimitives, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>Z:\releases\Metrilus.Framework\v.19.2.0.1\lib\MetriPrimitives.dll</HintPath>
+      <HintPath>Z:\releases\Metrilus.Framework\v.19.4.0.42\lib\MetriPrimitives.dll</HintPath>
     </Reference>
     <Reference Include="MetriPrimitivesNative, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>Z:\releases\Metrilus.Framework\v.19.2.0.1\lib\MetriPrimitivesNative.dll</HintPath>
+      <HintPath>Z:\releases\Metrilus.Framework\v.19.4.0.42\lib\MetriPrimitivesNative.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -87,6 +102,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\BetaCameras\OrbbecOpenNI\OrbbecOpenNI.vcxproj">
+      <Project>{c82202f8-55db-4511-b006-c88ff3e4427e}</Project>
+      <Name>OrbbecOpenNI</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\BetaCameras\Sick.VisionaryT\Sick.VisionaryT.csproj">
       <Project>{de18d143-c624-4941-b8a1-0f91262d3350}</Project>
       <Name>Sick.VisionaryT</Name>
@@ -101,6 +120,13 @@
       <Link>.licenseheader</Link>
     </None>
     <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Samples/MinimalSample/app.config
+++ b/Samples/MinimalSample/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>


### PR DESCRIPTION
This makes MetriCam's Orbbec wrapper compatible with current Orbbec Astra Mini S devices - and hopefully other current devices, too.

Suggested commit message for the squash commit:

```
Orbbec improvements

- Compatibility with current devices
- Cleaner OpenNI2 init/shutdown
- Faster device discovery
- Several minor improvements
```