### PR TITLE
Orbbec: Code clean up

### DIFF
--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.cpp
@@ -231,13 +231,13 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 	VendorID = dInfo.getUsbVendorId();
 	ProductID = dInfo.getUsbProductId();
 
-	//Check whether the camera has a color channel.
+	// Check whether the camera has a color channel.
 	_hasColor = Device.hasSensor(openni::SensorType::SENSOR_COLOR);
 	if (!_hasColor)
 	{
 		if (IsChannelActive((ChannelNames::Color)))
 		{
-			log->Warn("This camera does not support the channel \"Color\". Deactivating and removing channel \"Color\"...");
+			log->Warn("This camera does not support the channel \"" + ChannelNames::Color + "\". Deactivating and removing channel \"" + ChannelNames::Color + "\"...");
 			DeactivateChannel(ChannelNames::Color);
 		}
 		Channels->Remove(GetChannelDescriptor(ChannelNames::Color));
@@ -248,14 +248,15 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 	Device.getProperty(openni::OBEXTENSION_ID_DEVICETYPE, deviceType, &size);
 	DeviceType = gcnew String(deviceType);
 	Model = DeviceType->StartsWith("Orbbec ") ? DeviceType->Substring(7) : DeviceType; //1st gen device types start with string "Orbbec ", 2nd gen devices not.
-	if (ProductID == 1547 || ProductID == 1544) //2nd gen device types are: Embedded S and Stereo S
+	if (ProductID == ProductIDs::EmbeddedS || ProductID == ProductIDs::StereoS)
 	{
+		// 2nd Gen devices
 		_useI2CGain = false;
 		_irGainMin = IR_Gain_2nd_gen_MIN;
 		_irGainMax = IR_Gain_2nd_gen_MAX;
 		_intensityYTranslation = 0;
 		_depthResolution = Point2i(640, 400);
-		if (ProductID == 1547)
+		if (ProductID == ProductIDs::EmbeddedS)
 		{
 			_depthFps = 60; //Embedded S is the only model which supports 60fps.
 		}
@@ -264,9 +265,10 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 			_depthFps = 30;
 		}
 	}
-	else //1st gen device types are: Astra, Astra S, Astra Pro, Astra Mini, Astra Mini S
-	{				
-		_intensityYTranslation = 16; //1st gen shift between IR and color.
+	else
+	{
+		// 1st Gen devices: Astra, Astra S, Astra Pro, Astra Mini, Astra Mini S
+		_intensityYTranslation = 16; // 1st Gen shift between IR and color.
 		_useI2CGain = true;
 		_irGainMin = IR_Gain_1st_gen_MIN;
 		_irGainMax = IR_Gain_1st_gen_MAX;
@@ -299,7 +301,7 @@ void MetriCam2::Cameras::AstraOpenNI::ConnectImpl()
 		InitColorStream();
 		if (IsChannelActive(ChannelNames::Intensity) && IsChannelActive(ChannelNames::Color))
 		{
-			log->Warn("This camera does not support to fetch the channels \"Color\" and \"Intensity\" in parallel. Deactivating channel \"Intensity\"...");
+			log->Warn("This camera does not support to fetch the channels \"" + ChannelNames::Color + "\" and \"" + ChannelNames::Intensity + "\" in parallel. Deactivating channel \"" + ChannelNames::Intensity + "\"...");
 			DeactivateChannel(ChannelNames::Intensity);
 		}
 	}
@@ -667,7 +669,7 @@ void MetriCam2::Cameras::AstraOpenNI::ActivateChannelImpl(String^ channelName)
 		{
 			if (IsChannelActive(ChannelNames::Color))
 			{
-				log->Warn("This camera does not support to fetch the channels \"Intensity\" and \"Color\" in parallel. Deactivating channel \"Color\"...");
+				log->Warn("This camera does not support to fetch the channels \"" + ChannelNames::Intensity + "\" and \"" + ChannelNames::Color + "\" in parallel. Deactivating channel \"" + ChannelNames::Color + "\"...");
 				DeactivateChannel(ChannelNames::Color);
 			}
 		}
@@ -701,7 +703,7 @@ void MetriCam2::Cameras::AstraOpenNI::ActivateChannelImpl(String^ channelName)
 		if (IsChannelActive(ChannelNames::Intensity))
 		{
 			//Color cannot by activated if intensity is active -> Deactivate intensity channel.
-			log->Warn("This camera does not support to fetch the channels \"Color\" and \"Intensity\" in parallel. Deactivating channel \"Intensity\"...");
+			log->Warn("This camera does not support to fetch the channels \"" + ChannelNames::Color + "\" and \"" + ChannelNames::Intensity + "\" in parallel. Deactivating channel \"" + ChannelNames::Intensity + "\"...");
 			DeactivateChannel(ChannelNames::Intensity);
 		}
 

--- a/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
+++ b/BetaCameras/OrbbecOpenNI/OrbbecOpenNI.h
@@ -16,6 +16,12 @@ const int IR_Gain_1st_gen_MAX = 63;
 const int IR_Gain_2nd_gen_MIN = 64;
 const int IR_Gain_2nd_gen_MAX = 15999;
 
+enum ProductIDs
+{
+	StereoS = 1544,
+	EmbeddedS = 1547
+};
+
 using namespace System;
 using namespace System::ComponentModel;
 using namespace System::Threading;
@@ -333,8 +339,8 @@ namespace MetriCam2
 			OrbbecNativeCameraData* _pCamData;
 			int _vid;
 			int _pid;
-			// When USE_I2C_GAIN is set, then the old, I2C code is used to get/set the IrGain.
-			// Otherwise, the new Orbbec OpenNI extension is used (which seems still buggy).
+			// When _useI2CGain is set, then the old, I2C code is used to get/set the IrGain.
+			// Otherwise, the new Orbbec OpenNI extension is used (which seems still buggy but works for 2nd Gen models).
 			bool _useI2CGain;
 			int _irGainMin;
 			int _irGainMax;


### PR DESCRIPTION
Minor changes to Orbbec code.

Maybe in the future we could have collections of product IDs like
```csharp
List<int> SupportsOpenNIGain = new List<int> { ProductIDs.EmbeddedS, ProductIDs.StereoS };
```
I think that might become useful once we had multiple of those collections.

Or have a struct defining the relevant camera properties, e.g. the intensity offset.

Well, dreams...