### PR TITLE
Build nuget packages

### DIFF
--- a/BetaCameras/Kinect2/Kinect2.csproj
+++ b/BetaCameras/Kinect2/Kinect2.csproj
@@ -2,16 +2,12 @@
   <PropertyGroup>
     <RootNamespace>MetriCam2.Cameras</RootNamespace>
     <AssemblyName>MetriCam2.Cameras.Kinect2</AssemblyName>
-    <Description>Wrapper for Kinect2 camera</Description>
-    <Product>MetriCam2: Microsoft Kinect2 wrapper</Product>
+    <Description>Wrapper for Microsoft Kinect for Windows v2 camera</Description>
+    <Product>MetriCam2: Microsoft Kinect for Windows v2 wrapper</Product>
     <TargetFrameworks>net472;net45</TargetFrameworks>    
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>    
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>    
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Kinect">
-      <HintPath>Z:\external-libraries\Microsoft\Kinect2\v2.0_1409\Assemblies\Microsoft.Kinect.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -21,6 +17,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="KinectIcon.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Kinect" Version="2.0.1410.19000" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MetriCam2\MetriCam2.csproj" />

--- a/BetaCameras/Kinect2/Kinect2.csproj
+++ b/BetaCameras/Kinect2/Kinect2.csproj
@@ -6,8 +6,14 @@
     <Product>MetriCam2: Microsoft Kinect for Windows v2 wrapper</Product>
     <TargetFrameworks>net472;net45</TargetFrameworks>    
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>    
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>    
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -18,6 +24,11 @@
   <ItemGroup>
     <EmbeddedResource Include="KinectIcon.ico" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Kinect" Version="2.0.1410.19000" />
   </ItemGroup>

--- a/BetaCameras/Kinect4Azure/Kinect4Azure.csproj
+++ b/BetaCameras/Kinect4Azure/Kinect4Azure.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>MetriCam2.Cameras</RootNamespace>
-    <AssemblyName>MetriCam2.Cameras.Kinect4Azure</AssemblyName>
+    <AssemblyName>MetriCam2.Cameras.AzureKinect</AssemblyName>
     <Description>Wrapper for Microsoft Azure Kinect (K4A) cameras</Description>
     <Product>MetriCam2: Microsoft Azure Kinect wrapper</Product>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/BetaCameras/Kinect4Azure/Kinect4Azure.csproj
+++ b/BetaCameras/Kinect4Azure/Kinect4Azure.csproj
@@ -7,8 +7,14 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -19,6 +25,11 @@
   <ItemGroup>
     <EmbeddedResource Include="MSIcon.ico" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Kinect.Sensor" Version="1.2.0" />
   </ItemGroup>

--- a/BetaCameras/Kinect4Azure/MetriCam2.Kinect4Azure.props
+++ b/BetaCameras/Kinect4Azure/MetriCam2.Kinect4Azure.props
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="PropertySheets" />
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Kinect.Sensor">
-      <Version>1.2.0</Version>
-    </PackageReference>
-  </ItemGroup>
-</Project>

--- a/MetriCam2.Controls/MetriCam2.Controls.csproj
+++ b/MetriCam2.Controls/MetriCam2.Controls.csproj
@@ -1,9 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net45</TargetFrameworks>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>WinForms controls for MetriCam2</Description>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
@@ -99,6 +105,7 @@
     <None Include="..\.licenseheader">
       <Link>.licenseheader</Link>
     </None>
+    <None Include="..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\ConnectedOverlay.ico" />

--- a/MetriCam2.Controls/MetriCam2.Controls.csproj
+++ b/MetriCam2.Controls/MetriCam2.Controls.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net45</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Description>WinForms controls for MetriCam2</Description>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />

--- a/MetriCam2/MetriCam2.csproj
+++ b/MetriCam2/MetriCam2.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net45;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +19,7 @@
 
   <ItemGroup>
     <None Include="..\.licenseheader" Link=".licenseheader" />
+    <None Include="..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MetriCam2/MetriCam2.csproj
+++ b/MetriCam2/MetriCam2.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net45;netstandard2.0</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Scripts/Jenkinsfile.groovy
+++ b/Scripts/Jenkinsfile.groovy
@@ -125,8 +125,6 @@ pipeline {
 
                     copy /Y \"BetaCameras\\OrbbecOpenNI\\MetriCam2.Orbbec.props\" \"${releaseDirectory}\"
                     if errorlevel 1 GOTO StepFailed
-                    copy /Y \"BetaCameras\\Kinect4Azure\\MetriCam2.Kinect4Azure.props\" \"${releaseDirectory}\"
-                    if errorlevel 1 GOTO StepFailed
                     exit /b 0
 
                     :StepFailed

--- a/Scripts/Jenkinsfile.groovy
+++ b/Scripts/Jenkinsfile.groovy
@@ -137,11 +137,11 @@ pipeline {
 
                     copy \"License.txt\" \"${releaseDirectory}\"
                     if errorlevel 1 GOTO StepFailed
-                    exit /b 0
 
                     @echo Publishing nuget packages locally...
                     copy \"bin\\Release\\*.nupkg\" \"${releaseDirectory}\"
                     if errorlevel 1 GOTO StepFailed
+                    exit /b 0
 
                     :StepFailed
                     echo The step failed


### PR DESCRIPTION
Build nuget packages for MetriCam2, MetriCam2.Controls, AzureKinect and Kinect for Windows v2.

Kinect for Windows v2 now uses the nuget reference instead of a local reference to `Z:\external-libraries`.