### PR TITLE
Create nuget packages for Basler{ACE,ToF}, ifm and Sick VisionaryT

### DIFF
--- a/BetaCameras/BaslerACE/BaslerACE.csproj
+++ b/BetaCameras/BaslerACE/BaslerACE.csproj
@@ -7,10 +7,20 @@
     <TargetFrameworks>net472;net45</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Platforms>x64</Platforms>
+    <BaslerPylonPath>Z:\external-libraries\Basler\acA1300\pylon 5.0.11\Basler.Pylon\x64\Basler.Pylon.dll</BaslerPylonPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="$(BaslerPylonPath)" PackagePath="lib\net472;lib\net45" Visible="false" />
+    <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Basler.Pylon">
-      <HintPath>Z:\external-libraries\Basler\acA1300\pylon 5.0.11\Basler.Pylon\x64\Basler.Pylon.dll</HintPath>
+      <HintPath>$(BaslerPylonPath)</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
   </ItemGroup>
@@ -22,7 +32,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="BaslerIcon.ico" />
+    <EmbeddedResource Include="BaslerIcon.ico" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MetriCam2\MetriCam2.csproj" />

--- a/BetaCameras/BaslerToF/BaslerToF.csproj
+++ b/BetaCameras/BaslerToF/BaslerToF.csproj
@@ -8,10 +8,20 @@
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>false</SignAssembly>
+    <ToFCameraWrapperPath>Z:\external-libraries\Basler\ToF Camera\v1.3.2.1322\ToFCameraWrapper.dll</ToFCameraWrapperPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="$(ToFCameraWrapperPath)" PackagePath="lib\net472;lib\net45" Visible="false" />
+    <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="ToFCameraWrapper">
-      <HintPath>Z:\external-libraries\Basler\ToF Camera\v1.3.2.1322\ToFCameraWrapper.dll</HintPath>
+      <HintPath>$(ToFCameraWrapperPath)</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -22,7 +32,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="BaslerIcon.ico" />
+    <EmbeddedResource Include="BaslerIcon.ico" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MetriCam2\MetriCam2.csproj" />

--- a/BetaCameras/Sick.VisionaryT/Sick.VisionaryT.csproj
+++ b/BetaCameras/Sick.VisionaryT/Sick.VisionaryT.csproj
@@ -7,6 +7,14 @@
     <TargetFrameworks>net472;net45</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/BetaCameras/ifm/ifm.csproj
+++ b/BetaCameras/ifm/ifm.csproj
@@ -5,7 +5,15 @@
     <TargetFrameworks>net472;net45</TargetFrameworks>
     <Description>Wrapper for ifm O3D3xx cameras</Description>
     <Product>MetriCam2: ifm O3D3xx wrapper</Product>
-  </PropertyGroup>  
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Scripts/Jenkinsfile.groovy
+++ b/Scripts/Jenkinsfile.groovy
@@ -138,6 +138,8 @@ pipeline {
                     if errorlevel 1 GOTO StepFailed
 
                     @echo Deleting nuget packages, which should not be published to nuget.org...
+                    del /s \"bin\\Release\\MetriCam2.Cameras.Basler*.nupkg\"
+                    if errorlevel 1 GOTO StepFailed
                     del /s \"bin\\Release\\MetriCam2.Cameras.OrbbecOpenNI*.nupkg\"
                     if errorlevel 1 GOTO StepFailed
                     exit /b 0


### PR DESCRIPTION
Remark: `ifm` and `Sick VisionaryT` do not have non-nuget dependencies, so we can push the packages to `nuget.org`